### PR TITLE
benches: Implement benches for read op

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["storage", "data", "s3"]
 categories = ["filesystem"]
 
 [[bench]]
-name = "s3"
+name = "ops"
 harness = false
 
 [dependencies]

--- a/benches/ops/fs.rs
+++ b/benches/ops/fs.rs
@@ -1,0 +1,33 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::env;
+
+use anyhow::Result;
+
+use opendal::services::fs;
+use opendal::Operator;
+
+pub async fn init() -> Result<Operator> {
+    if env::var("OPENDAL_FS_TEST").is_err() || env::var("OPENDAL_FS_TEST").unwrap() != "on" {
+        return Err(anyhow::anyhow!("OPENDAL_FS_TEST is not set, skipping."));
+    }
+
+    Ok(Operator::new(
+        fs::Backend::build()
+            .root(&env::var("OPENDAL_FS_ROOT")?)
+            .finish()
+            .await
+            .expect("init fs"),
+    ))
+}

--- a/benches/ops/main.rs
+++ b/benches/ops/main.rs
@@ -11,26 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use criterion::{criterion_group, criterion_main, Criterion};
-use opendal::credential::Credential;
+mod fs;
+mod ops;
+mod s3;
 
-async fn init() {
-    opendal::services::s3::Backend::build()
-        .bucket("test")
-        .region("test")
-        .credential(Credential::hmac("test", "test"))
-        .finish()
-        .await
-        .unwrap();
-}
+use criterion::{criterion_group, criterion_main};
 
-fn criterion_benchmark(c: &mut Criterion) {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-
-    c.bench_function("s3_init", |b| {
-        b.to_async(&runtime).iter(|| init());
-    });
-}
-
-criterion_group!(benches, criterion_benchmark);
+criterion_group!(benches, ops::bench);
 criterion_main!(benches);

--- a/benches/ops/ops.rs
+++ b/benches/ops/ops.rs
@@ -1,0 +1,87 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{BenchmarkId, Criterion};
+use futures::io;
+use futures::io::BufReader;
+use futures::io::Cursor;
+use rand::prelude::*;
+
+use opendal::readers::SeekableReader;
+use opendal::Operator;
+
+use super::fs;
+use super::s3;
+
+pub fn bench(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let mut rng = thread_rng();
+
+    let size = 16 * 1024 * 1024; // Test with 16MB.
+    let content = gen_bytes(&mut rng, size);
+
+    let cases = vec![
+        ("fs", runtime.block_on(fs::init())),
+        ("s3", runtime.block_on(s3::init())),
+    ];
+
+    for case in cases {
+        if case.1.is_err() {
+            continue;
+        }
+        let op = case.1.unwrap();
+        let path = uuid::Uuid::new_v4().to_string();
+
+        // Write file before test.
+        runtime
+            .block_on(
+                op.write(&path, size as u64)
+                    .run(Box::new(Cursor::new(content.clone()))),
+            )
+            .expect("write failed");
+
+        let mut group = c.benchmark_group(case.0);
+        group.throughput(criterion::Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("bench_read", &path),
+            &(op.clone(), &path),
+            |b, input| b.iter(|| bench_read(input.0.clone(), input.1)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("bench_seekable_read", &path),
+            &(op.clone(), &path, size),
+            |b, input| b.iter(|| bench_seekable_read(input.0.clone(), input.1, input.2 as u64)),
+        );
+        group.finish();
+    }
+}
+
+fn gen_bytes(rng: &mut ThreadRng, size: usize) -> Vec<u8> {
+    let mut content = vec![0; size as usize];
+    rng.fill_bytes(&mut content);
+
+    content
+}
+
+pub async fn bench_read(op: Operator, path: &str) {
+    let mut r = op.read(path).run().await.unwrap();
+    io::copy(&mut r, &mut io::sink()).await.unwrap();
+}
+
+pub async fn bench_seekable_read(op: Operator, path: &str, total: u64) {
+    let r = SeekableReader::new(op, path, total);
+    let mut r = BufReader::with_capacity(4 * 1024 * 1024, r);
+
+    io::copy_buf(&mut r, &mut io::sink()).await.unwrap();
+}

--- a/benches/ops/s3.rs
+++ b/benches/ops/s3.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::env;
+
+use anyhow::Result;
+use opendal::credential::Credential;
+use opendal::services::s3;
+use opendal::Operator;
+
+pub async fn init() -> Result<Operator> {
+    if env::var("OPENDAL_S3_TEST").is_err() || env::var("OPENDAL_S3_TEST").unwrap() != "on" {
+        return Err(anyhow::anyhow!("OPENDAL_S3_TEST is not set, skipping."));
+    }
+
+    Ok(Operator::new(
+        s3::Backend::build()
+            .root(&format!("/{}", uuid::Uuid::new_v4()))
+            .bucket(&env::var("OPENDAL_S3_BUCKET")?)
+            .region(&env::var("OPENDAL_S3_REGION")?)
+            .endpoint(&env::var("OPENDAL_S3_ENDPOINT")?)
+            .credential(Credential::hmac(
+                &env::var("OPENDAL_S3_ACCESS_KEY_ID")?,
+                &env::var("OPENDAL_S3_SECRET_ACCESS_KEY")?,
+            ))
+            .finish()
+            .await
+            .expect("init s3"),
+    ))
+}


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR adds benches for read op, we will extend the benchmark to all core ops.
