### PR TITLE
credential: Add Plain variant to allow more input

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -14,6 +14,9 @@
 
 #[derive(Debug, Clone)]
 pub enum Credential {
+    /// Plain refers to no credential has been provided, fallback to services'
+    /// default logic.
+    Plain,
     /// Basic refers to HTTP Basic Authentication.
     Basic { username: String, password: String },
     /// HMAC, also known as Access Key/Secret Key authentication.
@@ -33,6 +36,10 @@ pub enum Credential {
 
 impl Credential {
     pub fn basic(username: &str, password: &str) -> Credential {
+        if username.is_empty() && password.is_empty() {
+            return Credential::Plain;
+        }
+
         Credential::Basic {
             username: username.to_string(),
             password: password.to_string(),
@@ -40,6 +47,10 @@ impl Credential {
     }
 
     pub fn hmac(access_key_id: &str, secret_access_key: &str) -> Credential {
+        if access_key_id.is_empty() && secret_access_key.is_empty() {
+            return Credential::Plain;
+        }
+
         Credential::HMAC {
             access_key_id: access_key_id.to_string(),
             secret_access_key: secret_access_key.to_string(),
@@ -47,6 +58,10 @@ impl Credential {
     }
 
     pub fn token(token: &str) -> Credential {
+        if token.is_empty() {
+            return Credential::Plain;
+        }
+
         Credential::Token(token.to_string())
     }
 }

--- a/src/services/s3.rs
+++ b/src/services/s3.rs
@@ -258,6 +258,8 @@ impl Builder {
                         None,
                     ));
                 }
+                // We don't need to do anything if user tries to read credential from env.
+                Credential::Plain => {}
                 _ => {
                     return Err(Error::Backend {
                         kind: Kind::BackendConfigurationInvalid,


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add Plain variant to allow more input.

fix #77 

Databend will pass users' input directly without checking:

https://github.com/datafuselabs/databend/blob/f76e4756f859abf697c4a405c01f85621227904c/query/src/sessions/session_mgr.rs#L284-L288

We should check the empty credential and fall back to default logic instead.