### PR TITLE
object: Refactor ObjectMode into enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
-    needs: check
     strategy:
       matrix:
         os:
@@ -33,7 +32,6 @@ jobs:
 
   unit:
     runs-on: ${{ matrix.os }}
-    needs: check
     strategy:
       matrix:
         os:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ aws-smithy-client = "0.38"
 aws-smithy-http = "0.38"
 aws-smithy-http-tower = "0.38"
 aws-types = { version = "0.8", features = ["hardcoded-credentials"] }
-bitflags = "1"
 blocking = "1"
 bytes = "1"
 futures = { version = "0.3", features = ["alloc"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         let meta = o.metadata().await?;
         if meta.path().contains("test_file") {
             let mode = meta.mode();
-            assert!(mode.contains(ObjectMode::FILE));
+            assert_eq!(mode, ObjectMode::FILE);
 
             found = true
         }

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,14 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-use bitflags::bitflags;
 use futures::future::BoxFuture;
 use futures::ready;
 
@@ -185,12 +184,26 @@ impl Metadata {
     }
 }
 
-bitflags! {
-    #[derive(Default)]
-    pub struct ObjectMode: u32 {
-        const FILE =1<<0;
-        const DIR = 1<<1;
-        const LINK = 1<<2;
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ObjectMode {
+    FILE,
+    DIR,
+    Unknown,
+}
+
+impl Default for ObjectMode {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+impl Display for ObjectMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObjectMode::FILE => write!(f, "file"),
+            ObjectMode::DIR => write!(f, "dir"),
+            ObjectMode::Unknown => write!(f, "unknown"),
+        }
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/object.rs
+++ b/src/object.rs
@@ -184,10 +184,14 @@ impl Metadata {
     }
 }
 
+/// ObjectMode represents the corresponding object's mode.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ObjectMode {
+    /// FILE means the object has data to read.
     FILE,
+    /// DIR means the object can be listed.
     DIR,
+    /// Unknown means we don't know what we can do on thi object.
     Unknown,
 }
 

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -108,12 +108,7 @@ impl BehaviorTest {
             let meta = o.metadata().await?;
             if meta.path() == path {
                 let mode = meta.mode();
-                assert!(
-                    mode.contains(ObjectMode::FILE),
-                    "expected: {:?}, actual: {:?}",
-                    ObjectMode::FILE,
-                    mode
-                );
+                assert_eq!(mode, ObjectMode::FILE);
 
                 found = true
             }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

object: Refactor ObjectMode into enum
