### PR TITLE
fix: Stat root should return a dir object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
           args: --no-fail-fast
         env:
           RUST_TEST_THREADS: '2'
-          RUST_LOG: ERROR
+          RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/.github/workflows/service_test_fs.yml
+++ b/.github/workflows/service_test_fs.yml
@@ -24,5 +24,6 @@ jobs:
         run: cargo test fs
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: debug
           OPENDAL_FS_TEST: on
           OPENDAL_FS_ROOT: /tmp

--- a/.github/workflows/service_test_memory.yml
+++ b/.github/workflows/service_test_memory.yml
@@ -24,4 +24,5 @@ jobs:
         run: cargo test memory
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: debug
           OPENDAL_MEMORY_TEST: on

--- a/.github/workflows/service_test_s3.yml
+++ b/.github/workflows/service_test_s3.yml
@@ -19,6 +19,7 @@ jobs:
         run: cargo test s3
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: debug
           OPENDAL_S3_TEST: ${{ secrets.OPENDAL_S3_TEST }}
           OPENDAL_S3_ROOT: ${{ secrets.OPENDAL_S3_ROOT }}
           OPENDAL_S3_BUCKET: ${{ secrets.OPENDAL_S3_BUCKET }}
@@ -56,6 +57,7 @@ jobs:
         run: cargo test s3
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: debug
           OPENDAL_S3_TEST: on
           OPENDAL_S3_BUCKET: test
           OPENDAL_S3_ENDPOINT: "http://127.0.0.1:9000"
@@ -93,6 +95,7 @@ jobs:
         run: cargo test s3
         env:
           RUST_BACKTRACE: full
+          RUST_LOG: debug
           OPENDAL_S3_TEST: on
           OPENDAL_S3_BUCKET: test
           OPENDAL_S3_ENDPOINT: "http://127.0.0.1:9000"

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -46,6 +46,13 @@ pub trait Accessor: Send + Sync + Debug {
         unimplemented!()
     }
     /// Invoke the `stat` operation on the specified path.
+    ///
+    /// ## Behavior
+    ///
+    /// - `Stat` empty path means stat backend's root path.
+    /// - `Stat` a path endswith "/" means stating a dir.
+    ///   - On fs, an error could return if not a dir.
+    ///   - On s3 alike backends, a dir object will return no matter it exist or not.
     async fn stat(&self, args: &OpStat) -> Result<Metadata> {
         let _ = args;
         unimplemented!()

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -149,7 +149,7 @@ impl Accessor for Backend {
     async fn stat(&self, args: &OpStat) -> Result<Metadata> {
         let path = Backend::normalize_path(&args.path);
 
-        if path.ends_with('/') {
+        if path.ends_with('/') || path.is_empty() {
             let mut meta = Metadata::default();
             meta.set_path(&path)
                 .set_mode(ObjectMode::DIR)

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -438,8 +438,11 @@ impl Accessor for Backend {
     async fn stat(&self, args: &OpStat) -> Result<Metadata> {
         increment_counter!("opendal_s3_stat_requests");
 
+        let p = self.get_abs_path(&args.path);
+        info!("object {} stat start", &p);
+
         // Stat root always returns a DIR.
-        if args.path.is_empty() {
+        if p == self.get_abs_path(&self.root) {
             let mut m = Metadata::default();
             m.set_path(&args.path);
             m.set_content_length(0);
@@ -449,9 +452,6 @@ impl Accessor for Backend {
             info!("backed root object stat finished");
             return Ok(m);
         }
-
-        let p = self.get_abs_path(&args.path);
-        info!("object {} stat start", &p);
 
         let meta = self
             .client

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -438,6 +438,18 @@ impl Accessor for Backend {
     async fn stat(&self, args: &OpStat) -> Result<Metadata> {
         increment_counter!("opendal_s3_stat_requests");
 
+        // Stat root always returns a DIR.
+        if args.path.is_empty() {
+            let mut m = Metadata::default();
+            m.set_path(&args.path);
+            m.set_content_length(0);
+            m.set_mode(ObjectMode::DIR);
+            m.set_complete();
+
+            info!("backed root object stat finished");
+            return Ok(m);
+        }
+
         let p = self.get_abs_path(&args.path);
         info!("object {} stat start", &p);
 

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -442,7 +442,7 @@ impl Accessor for Backend {
         info!("object {} stat start", &p);
 
         // Stat root always returns a DIR.
-        if p == self.get_abs_path(&self.root) {
+        if self.get_rel_path(&p).is_empty() {
             let mut m = Metadata::default();
             m.set_path(&args.path);
             m.set_content_length(0);

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -364,6 +364,7 @@ impl Backend {
 
     /// get_rel_path will return the relative path of the given path in the s3 format.
     pub(crate) fn get_rel_path(&self, path: &str) -> String {
+        let path = Backend::normalize_path(path);
         let path = format!("/{}", path);
 
         match path.strip_prefix(&self.root) {

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -132,6 +132,9 @@ impl BehaviorTest {
         let meta = self.op.object("").metadata().await?;
         assert_eq!(meta.mode(), ObjectMode::DIR);
 
+        let meta = self.op.object("/").metadata().await?;
+        assert_eq!(meta.mode(), ObjectMode::DIR);
+
         Ok(())
     }
 

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -49,6 +49,7 @@ impl BehaviorTest {
 
     pub async fn run(&mut self) -> Result<()> {
         self.test_normal().await?;
+        self.test_stat_root().await?;
 
         Ok(())
     }
@@ -123,6 +124,14 @@ impl BehaviorTest {
         let o = self.op.object(&path);
         let exist = o.is_exist().await?;
         assert!(!exist, "stat file again");
+        Ok(())
+    }
+
+    /// Root should be able to stat and returns DIR.
+    async fn test_stat_root(&mut self) -> Result<()> {
+        let meta = self.op.object("").metadata().await?;
+        assert_eq!(meta.mode(), ObjectMode::DIR);
+
         Ok(())
     }
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Stat root should return a dir object
