### PR TITLE
docs: Fix wrong URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenDAL &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
 [Build Status]: https://img.shields.io/github/workflow/status/datafuselabs/opendal/CI/main
-[actions]: https://github.com/datafuselabs/opendal/actions?query=branch%3Amaster
+[actions]: https://github.com/datafuselabs/opendal/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/opendal.svg
 [crates.io]: https://crates.io/crates/opendal
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

docs: Fix wrong URL in README
