### PR TITLE
refactor: Adopt io::Result instead

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -17,6 +17,12 @@ runs:
         command: fmt
         args: --all -- --check
 
+    - name: Doc check
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps
+
     - name: Check License Header
       uses: apache/skywalking-eyes@main
       env:

--- a/opendal_test/src/services/azblob.rs
+++ b/opendal_test/src/services/azblob.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::env;
+use std::io::Result;
 use std::sync::Arc;
 
-use opendal::error::Result;
 use opendal::services::azblob;
 use opendal::Accessor;
 

--- a/opendal_test/src/services/fs.rs
+++ b/opendal_test/src/services/fs.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::env;
+use std::io::Result;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use opendal::error::Result;
 use opendal::services::fs;
 use opendal::Accessor;
 

--- a/opendal_test/src/services/memory.rs
+++ b/opendal_test/src/services/memory.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::env;
+use std::io::Result;
 use std::sync::Arc;
 
-use opendal::error::Result;
 use opendal::services::memory;
 use opendal::Accessor;
 

--- a/opendal_test/src/services/s3.rs
+++ b/opendal_test/src/services/s3.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::env;
+use std::io::Result;
 use std::sync::Arc;
 
-use opendal::error::Result;
 use opendal::services::s3;
 use opendal::Accessor;
 

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use std::fmt::Debug;
+use std::io::Result;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::error::Result;
 use crate::io::BytesSinker;
 use crate::io::BytesStreamer;
 use crate::ops::OpDelete;

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Error;
+use std::io::Result;
+
 use bytes::Bytes;
 use futures::AsyncRead;
 use futures::AsyncWrite;
 use futures::Sink;
 use futures::Stream;
-
-use crate::error::Error;
-use crate::error::Result;
 
 /// BytesRead represents a reader of bytes.
 pub trait BytesRead: AsyncRead + Unpin + Send {}

--- a/src/io_util/into_reader.rs
+++ b/src/io_util/into_reader.rs
@@ -35,8 +35,8 @@ use crate::BytesStream;
 ///
 /// ```rust
 /// use opendal::io_util::into_reader;
-/// # use opendal::error::Result;
-/// # use opendal::error::Error;
+/// # use anyhow::Result;
+/// # use std::io::Error;
 /// # use futures::io;
 /// # use bytes::Bytes;
 /// # use futures::StreamExt;
@@ -103,7 +103,7 @@ where
                     }
                     Some(Err(err)) => {
                         self.state = State::Eof;
-                        return Poll::Ready(Err(err.into()));
+                        return Poll::Ready(Err(err));
                     }
                     None => {
                         self.state = State::Eof;
@@ -120,12 +120,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io::Error;
+
     use futures::stream;
     use futures::AsyncReadExt;
     use rand::prelude::*;
 
     use super::*;
-    use crate::error::Error;
 
     #[tokio::test]
     async fn test_into_reader() {

--- a/src/io_util/into_stream.rs
+++ b/src/io_util/into_stream.rs
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Result;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 
-use anyhow::anyhow;
 use bytes::Bytes;
 use bytes::BytesMut;
 use futures::ready;
 use futures::Stream;
 use pin_project::pin_project;
 
-use crate::error::Error;
-use crate::error::Result;
 use crate::BytesRead;
 
 /// Convert [`BytesRead`][crate::BytesRead] into [`BytesStream`][crate::BytesStream].
@@ -37,7 +35,7 @@ use crate::BytesRead;
 ///
 /// ```rust
 /// use opendal::io_util::into_stream;
-/// # use opendal::error::Result;
+/// # use std::io::Result;
 /// # use futures::io;
 /// # use bytes::Bytes;
 /// # use futures::StreamExt;
@@ -82,7 +80,7 @@ where
         }
 
         match ready!(this.r.poll_read(cx, this.buf)) {
-            Err(err) => Poll::Ready(Some(Err(Error::Unexpected(anyhow!(err))))),
+            Err(err) => Poll::Ready(Some(Err(err))),
             Ok(0) => Poll::Ready(None),
             Ok(n) => {
                 let chunk = this.buf.split_to(n);

--- a/src/io_util/into_writer.rs
+++ b/src/io_util/into_writer.rs
@@ -34,7 +34,7 @@ use crate::BytesSink;
 /// ```rust
 /// use opendal::io_util::into_writer;
 /// # use opendal::io_util::into_sink;
-/// # use opendal::error::Result;
+/// # use std::io::Result;
 /// # use futures::io;
 /// # use bytes::Bytes;
 /// # use futures::StreamExt;
@@ -83,15 +83,11 @@ where
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.s)
-            .poll_flush(cx)
-            .map_err(io::Error::from)
+        Pin::new(&mut self.s).poll_flush(cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.s)
-            .poll_close(cx)
-            .map_err(io::Error::from)
+        Pin::new(&mut self.s).poll_close(cx)
     }
 }
 

--- a/src/io_util/sink_observer.rs
+++ b/src/io_util/sink_observer.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -19,9 +22,6 @@ use bytes::Bytes;
 use futures::Sink;
 use pin_project::pin_project;
 
-use crate::error::Error;
-use crate::error::Kind;
-use crate::error::Result;
 use crate::io::BytesSinker;
 
 /// Create an observer over BytesSink.
@@ -35,7 +35,7 @@ use crate::io::BytesSinker;
 /// use opendal::io_util::observe_sink;
 /// use opendal::io_util::SinkEvent;
 /// # use opendal::io_util::into_sink;
-/// # use opendal::error::Result;
+/// # use std::io::Result;
 /// # use futures::io;
 /// # use bytes::Bytes;
 /// # use futures::StreamExt;
@@ -77,7 +77,7 @@ pub enum SinkEvent {
     /// # Note
     ///
     /// We only emit the error kind here so that we don't need clone the whole error.
-    Error(Kind),
+    Error(ErrorKind),
 }
 
 /// Observer that created via [`observe_sink`].

--- a/src/io_util/stream_observer.rs
+++ b/src/io_util/stream_observer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::ErrorKind;
+use std::io::Result;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -20,8 +22,6 @@ use bytes::Bytes;
 use futures::Stream;
 use pin_project::pin_project;
 
-use crate::error::Kind;
-use crate::error::Result;
 use crate::BytesStreamer;
 
 /// Create an observer over BytesStream.
@@ -35,7 +35,7 @@ use crate::BytesStreamer;
 /// use opendal::io_util::observe_stream;
 /// use opendal::io_util::StreamEvent;
 /// # use opendal::io_util::into_stream;
-/// # use opendal::error::Result;
+/// # use std::io::Result;
 /// # use futures::io;
 /// # use bytes::Bytes;
 /// # use futures::StreamExt;
@@ -72,7 +72,7 @@ pub enum StreamEvent {
     /// # Note
     ///
     /// We only emit the error kind here so that we don't need clone the whole error.
-    Error(Kind),
+    Error(ErrorKind),
 }
 
 /// Observer that created via [`observe_stream`].

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -56,12 +56,12 @@ impl<T: Layer> Layer for Arc<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Result;
     use std::sync::Arc;
 
     use futures::lock::Mutex;
 
     use super::*;
-    use crate::error::Result;
     use crate::ops::OpDelete;
     use crate::services::fs;
     use crate::Accessor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@
 //! - [fs][crate::services::fs]: POSIX alike file system.
 //! - [memory][crate::services::memory]: In memory backend support.
 //! - [s3][crate::services::s3]: AWS services like S3.
+
+/// Private module with public types, they will be accessed via `opendal::Xxxx`
 mod accessor;
 pub use accessor::Accessor;
 
@@ -92,10 +94,15 @@ pub use object::ObjectStreamer;
 mod scheme;
 pub use scheme::Scheme;
 
-pub mod error;
+/// Public modules, they will be accessed via `opendal::io_util::Xxxx`
 pub mod io_util;
 pub mod ops;
 pub mod services;
+
+/// Private modules, internal use only.
+///
+/// Please don't export any type from this module.
+mod error;
 
 #[deprecated]
 pub mod readers;

--- a/src/object.rs
+++ b/src/object.rs
@@ -14,6 +14,8 @@
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::io::ErrorKind;
+use std::io::Result;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -24,8 +26,6 @@ use bytes::BytesMut;
 use futures::SinkExt;
 use futures::StreamExt;
 
-use crate::error::Kind;
-use crate::error::Result;
 use crate::io::BytesRead;
 use crate::io::BytesSinker;
 use crate::io::BytesStreamer;
@@ -72,7 +72,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// use bytes::{BufMut, BytesMut};
@@ -96,7 +96,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -113,7 +113,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -130,7 +130,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -158,7 +158,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -183,7 +183,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -217,7 +217,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -241,7 +241,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::TryStreamExt;
     /// # #[tokio::main]
@@ -274,7 +274,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// # use futures::SinkExt;
@@ -308,7 +308,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// # use futures::SinkExt;
@@ -342,7 +342,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// # use futures::SinkExt;
@@ -372,7 +372,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// # use futures::SinkExt;
@@ -399,7 +399,7 @@ impl Object {
     ///
     /// ```
     /// # use opendal::services::memory;
-    /// # use opendal::error::Result;
+    /// # use std::io::Result;
     /// # use opendal::Operator;
     /// # use futures::StreamExt;
     /// # use futures::SinkExt;
@@ -466,12 +466,13 @@ impl Object {
     /// # use anyhow::Result;
     /// # use futures::io;
     /// # use opendal::Operator;
-    /// # use opendal::error::Kind;
+    /// use std::io::ErrorKind;
+    /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<()> {
     /// # let op = Operator::new(memory::Backend::build().finish().await?);
     /// if let Err(e) = op.object("test").metadata().await {
-    ///     if e.kind() == Kind::ObjectNotExist {
+    ///     if e.kind() == ErrorKind::NotFound {
     ///         println!("object not exist")
     ///     }
     /// }
@@ -493,7 +494,7 @@ impl Object {
     /// use anyhow::Result;
     /// use futures::io;
     /// use opendal::Operator;
-    /// use opendal::error::Kind;
+    ///
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
@@ -527,7 +528,7 @@ impl Object {
     /// use anyhow::Result;
     /// use futures::io;
     /// use opendal::Operator;
-    /// use opendal::error::Kind;
+    ///
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
@@ -542,7 +543,7 @@ impl Object {
         match r {
             Ok(_) => Ok(true),
             Err(err) => match err.kind() {
-                Kind::ObjectNotExist => Ok(false),
+                ErrorKind::NotFound => Ok(false),
                 _ => Err(err),
             },
         }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::io::Result;
 use std::sync::Arc;
 
-use crate::error::Result;
 use crate::ops::OpList;
 use crate::Accessor;
 use crate::Layer;

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -1,3 +1,4 @@
+use std::io;
 // Copyright 2022 Datafuse Labs.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +16,8 @@ use std::str::FromStr;
 
 use anyhow::anyhow;
 
-use super::error::Error;
-use crate::error::Kind;
+use crate::error::other;
+use crate::error::BackendError;
 
 /// Backends that OpenDAL supports
 #[derive(Clone, Debug, PartialEq)]
@@ -29,7 +30,7 @@ pub enum Scheme {
 }
 
 impl FromStr for Scheme {
-    type Err = Error;
+    type Err = io::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_lowercase();
@@ -43,11 +44,10 @@ impl FromStr for Scheme {
             "local" | "disk" => Ok(Scheme::Fs),
             "azurestorageblob" => Ok(Scheme::Azblob),
 
-            v => Err(Error::Backend {
-                kind: Kind::BackendNotSupported,
-                context: Default::default(),
-                source: anyhow!("{} is not supported", v),
-            }),
+            v => Err(other(BackendError::new(
+                Default::default(),
+                anyhow!("{} is not supported", v),
+            ))),
         }
     }
 }

--- a/src/services/fs/error.rs
+++ b/src/services/fs/error.rs
@@ -12,35 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::Error;
-use crate::error::Kind;
+use std::io;
+use std::io::Error;
+
+use crate::error::ObjectError;
 
 /// Parse all path related errors.
 ///
 /// ## Notes
 ///
 /// Skip utf-8 check to allow invalid path input.
-pub fn parse_io_error(err: std::io::Error, op: &'static str, path: &str) -> Error {
-    use std::io::ErrorKind;
-
-    match err.kind() {
-        ErrorKind::NotFound => Error::Object {
-            kind: Kind::ObjectNotExist,
-            op,
-            path: path.to_string(),
-            source: anyhow::Error::from(err),
-        },
-        ErrorKind::PermissionDenied => Error::Object {
-            kind: Kind::ObjectPermissionDenied,
-            op,
-            path: path.to_string(),
-            source: anyhow::Error::from(err),
-        },
-        _ => Error::Object {
-            kind: Kind::Unexpected,
-            op,
-            path: path.to_string(),
-            source: anyhow::Error::from(err),
-        },
-    }
+pub fn parse_io_error(err: io::Error, op: &'static str, path: &str) -> io::Error {
+    Error::new(err.kind(), ObjectError::new(op, path, err))
 }

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -20,10 +20,11 @@
 //!
 //! For examples, we depends `write` to create a file before testing `read`. If `write` doesn't works well, we can't test `read` correctly too.
 
+use std::io::ErrorKind;
+
 use anyhow::Result;
 use futures::AsyncReadExt;
 use futures::StreamExt;
-use opendal::error::Kind;
 use opendal::ObjectMode;
 use opendal::Operator;
 use rand::prelude::*;
@@ -142,7 +143,7 @@ impl BehaviorTest {
             .await;
         assert!(meta.is_err());
         let err = meta.unwrap_err();
-        assert_eq!(err.kind(), Kind::ObjectNotExist);
+        assert_eq!(err.kind(), ErrorKind::NotFound);
         Ok(())
     }
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Adopt io::Result instead
