### PR TITLE
refactor: Move op.objects() to o.list()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ async fn main() -> Result<()> {
     let length: u64 = meta.content_length();
     let content_md5: Option<String> = meta.content_md5();
 
-    // List dir object.
-    let mut obs: ObjectStreamer = op.objects("").await?;
-    while let Some(o) = obs.next().await {}
-
     // Delete object.
     let _: () = o.delete().await?;
+
+    // List dir object.
+    let o: Object = op.object("test_dir/");
+    let mut obs: ObjectStreamer = o.list().await?;
+    while let Some(entry) = obs.next().await {
+        let entry: Object = entry?;
+    }
 
     Ok(())
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     assert_eq!(meta.content_length(), 13);
 
     // List current dir.
-    let mut obs = op.objects("").await?;
+    let mut obs = op.object("/").list().await?;
     let mut found = false;
     while let Some(o) = obs.next().await {
         let o = o?;

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     // Real example starts from here.
 
     // Start listing a dir.
-    let mut obs = op.objects("test_dir").await?;
+    let mut obs = op.object("test_dir/").list().await?;
     // ObjectStream implements `futures::Stream`
     while let Some(o) = obs.next().await {
         let mut o = o?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use anyhow::Result;
 //! use futures::StreamExt;
 //! use opendal::services::fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,15 @@
 //!     let length: u64 = meta.content_length();
 //!     let content_md5: Option<String> = meta.content_md5();
 //!
-//!     // List dir object.
-//!     let mut obs: ObjectStreamer = op.objects("").await?;
-//!     while let Some(o) = obs.next().await {}
-//!
 //!     // Delete object.
 //!     let _: () = o.delete().await?;
+//!
+//!     // List dir object.
+//!     let o: Object = op.object("test_dir/");
+//!     let mut obs: ObjectStreamer = o.list().await?;
+//!     while let Some(entry) = obs.next().await {
+//!         let entry: Object = entry?;
+//!     }
 //!
 //!     Ok(())
 //! }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Result;
 use std::sync::Arc;
 
-use crate::ops::OpList;
 use crate::Accessor;
 use crate::Layer;
 use crate::Object;
-use crate::ObjectStreamer;
 
 /// User-facing APIs for object and object streams.
 #[derive(Clone)]
@@ -84,50 +81,5 @@ impl Operator {
     /// Create a new [`Object`][crate::Object] handle to take operations.
     pub fn object(&self, path: &str) -> Object {
         Object::new(self.inner(), path)
-    }
-
-    /// Create a new [`ObjectStreamer`][crate::ObjectStreamer] handle to list objects.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use anyhow::Result;
-    /// use futures::StreamExt;
-    /// use opendal::ObjectMode;
-    /// use opendal::ObjectStream;
-    /// use opendal::Operator;
-    /// use opendal::services::fs;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<()> {
-    ///     let op = Operator::new(fs::Backend::build().root("/tmp").finish().await?);
-    ///
-    ///     op.object("test_dir/test_file").write("Hello, World!").await?;
-    ///
-    ///     // Start listing a dir.
-    ///     let mut obs = op.objects("test_dir/").await?;
-    ///     // ObjectStream implements `futures::Stream`
-    ///     while let Some(o) = obs.next().await {
-    ///         let mut o = o?;
-    ///         // It's highly possible that OpenDAL already did metadata during list.
-    ///         // Use `Object::metadata_cached()` to get cached metadata at first.
-    ///         let meta = o.metadata_cached().await?;
-    ///         match meta.mode() {
-    ///             ObjectMode::FILE => {
-    ///                 println!("Handling file")
-    ///             }
-    ///             ObjectMode::DIR => {
-    ///                 println!("Handling dir like start a new list via meta.path()")
-    ///             }
-    ///             ObjectMode::Unknown => continue,
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn objects(&self, path: &str) -> Result<ObjectStreamer> {
-        let op = OpList::new(&Object::normalize_path(path))?;
-        self.inner().list(&op).await
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Operations used by [`Accessor`][crate::Accessor]
+//! Operations used by [`Accessor`][crate::Accessor].
+//!
+//! Users should not use struct or functions here, use [`Operator`][crate::Operator] instead
 
 use std::collections::Bound;
 use std::io::Result;
@@ -34,6 +36,9 @@ pub struct OpCreate {
 }
 
 impl OpCreate {
+    /// Create a new `OpCreate`.
+    ///
+    /// If input path is not match with object mode, an error will be returned.
     pub fn new(path: &str, mode: ObjectMode) -> Result<Self> {
         match mode {
             ObjectMode::FILE => {
@@ -89,6 +94,9 @@ pub struct OpRead {
 }
 
 impl OpRead {
+    /// Create a new `OpRead`.
+    ///
+    /// If input path is not a file path, an error will be returned.
     pub fn new(path: &str, range: impl RangeBounds<u64>) -> Result<Self> {
         if path.ends_with('/') {
             return Err(other(ObjectError::new(
@@ -146,6 +154,7 @@ pub struct OpStat {
 }
 
 impl OpStat {
+    /// Create a new `OpStat`.
     pub fn new(path: &str) -> Result<Self> {
         Ok(Self {
             path: path.to_string(),
@@ -166,6 +175,9 @@ pub struct OpWrite {
 }
 
 impl OpWrite {
+    /// Create a new `OpWrite`.
+    ///
+    /// If input path is not a file path, an error will be returned.
     pub fn new(path: &str, size: u64) -> Result<Self> {
         if path.ends_with('/') {
             return Err(other(ObjectError::new(
@@ -197,6 +209,7 @@ pub struct OpDelete {
 }
 
 impl OpDelete {
+    /// Create a new `OpDelete`.
     pub fn new(path: &str) -> Result<Self> {
         Ok(Self {
             path: path.to_string(),
@@ -216,6 +229,9 @@ pub struct OpList {
 }
 
 impl OpList {
+    /// Create a new `OpList`.
+    ///
+    /// If input path is not a dir path, an error will be returned.
     pub fn new(path: &str) -> Result<Self> {
         if !path.ends_with('/') {
             return Err(other(ObjectError::new(

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -388,7 +388,7 @@ async fn test_list_dir(op: Operator) -> Result<()> {
         .await
         .expect("write must succeed");
 
-    let mut obs = op.objects("/").await?;
+    let mut obs = op.object("/").list().await?;
     let mut found = false;
     while let Some(o) = obs.next().await {
         let meta = o?.metadata().await?;
@@ -418,7 +418,7 @@ async fn test_list_sub_dir(op: Operator) -> Result<()> {
         .await
         .expect("create_dir must succeed");
 
-    let mut obs = op.objects("/").await?;
+    let mut obs = op.object("/").list().await?;
     let mut found = false;
     while let Some(o) = obs.next().await {
         let meta = o?.metadata().await?;
@@ -441,7 +441,7 @@ async fn test_list_sub_dir(op: Operator) -> Result<()> {
 async fn test_list_dir_with_file_path(op: Operator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
 
-    let obs = op.objects(&parent).await.map(|_| ());
+    let obs = op.object(&parent).list().await.map(|_| ());
     assert!(obs.is_err());
     assert!(obs.unwrap_err().to_string().contains("Not a directory"));
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Move op.objects() to o.list()
