### PR TITLE
fix(services/fs): Create on existing dir should succeed

### DIFF
--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -126,7 +126,7 @@ impl Accessor for Backend {
                 .parent()
                 .ok_or_else(|| {
                     other(ObjectError::new(
-                        "write",
+                        "create",
                         &path,
                         anyhow!("malformed path: {:?}", &path),
                     ))
@@ -134,7 +134,7 @@ impl Accessor for Backend {
                 .to_path_buf();
 
             fs::create_dir_all(&parent).await.map_err(|e| {
-                let e = parse_io_error(e, "write", &parent.to_string_lossy());
+                let e = parse_io_error(e, "create", &parent.to_string_lossy());
                 error!(
                     "object {} create_dir_all for parent {:?}: {:?}",
                     &path, &parent, e
@@ -148,7 +148,7 @@ impl Accessor for Backend {
                 .open(&path)
                 .await
                 .map_err(|e| {
-                    let e = parse_io_error(e, "write", &path);
+                    let e = parse_io_error(e, "create", &path);
                     error!("object {} create: {:?}", &path, e);
                     e
                 })?;

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -43,7 +43,9 @@ macro_rules! behavior_tests {
                 $service,
 
                 test_create_file,
+                test_create_file_existing,
                 test_create_dir,
+                test_create_dir_exising,
 
                 test_write,
                 test_write_with_dir_path,
@@ -123,11 +125,54 @@ async fn test_create_file(op: Operator) -> Result<()> {
     Ok(())
 }
 
+/// Create file on existing file path should succeed.
+async fn test_create_file_existing(op: Operator) -> Result<()> {
+    let path = uuid::Uuid::new_v4().to_string();
+
+    let o = op.object(&path);
+
+    let _ = o.create().await?;
+
+    let _ = o.create().await?;
+
+    let meta = o.metadata().await?;
+    assert_eq!(meta.path(), &path);
+    assert_eq!(meta.mode(), ObjectMode::FILE);
+    assert_eq!(meta.content_length(), 0);
+
+    op.object(&path)
+        .delete()
+        .await
+        .expect("delete must succeed");
+    Ok(())
+}
+
 /// Create dir with dir path should succeed.
 async fn test_create_dir(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
     let o = op.object(&path);
+
+    let _ = o.create().await?;
+
+    let meta = o.metadata().await?;
+    assert_eq!(meta.path(), &path);
+    assert_eq!(meta.mode(), ObjectMode::DIR);
+
+    op.object(&path)
+        .delete()
+        .await
+        .expect("delete must succeed");
+    Ok(())
+}
+
+/// Create dir on existing dir should succeed.
+async fn test_create_dir_exising(op: Operator) -> Result<()> {
+    let path = format!("{}/", uuid::Uuid::new_v4());
+
+    let o = op.object(&path);
+
+    let _ = o.create().await?;
 
     let _ = o.create().await?;
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/fs): Create on existing dir should succeed
