### PR TITLE
fix(services/s3): Endpoint without scheme should also supported

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ criterion = { version = "0.3.5", features = [
 ] }
 dotenv = "0.15.0"
 env_logger = "0.9.0"
+itertools = "0.10.3"
 num-traits = "0.2.14"
 opendal_test = { path = "./opendal_test" }
 paste = "1.0.7"


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/s3): Endpoint without scheme should also supported
