### PR TITLE
refactor(services): Convert all expect to errors instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ md5 = "0.7.0"
 metrics = "0.18.1"
 minitrace = "0.4.0"
 once_cell = "1.10.0"
+parking_lot = "0.12.0"
 pin-project = "1.0.10"
 quick-xml = { version = "0.22.0", features = ["serialize"] }
 reqsign = "0.0.3"


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(services): Convert all expect to errors instead
