### PR TITLE
refactor(object): Make Metadata::name() return &str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //!     // Get object's Metadata
 //!     let meta: Metadata = o.metadata().await?;
-//!     let name: String = meta.name();
+//!     let name: &str = meta.name();
 //!     let path: &str = meta.path();
 //!     let mode: ObjectMode = meta.mode();
 //!     let length: u64 = meta.content_length();

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -295,7 +295,13 @@ impl futures::Stream for EntryStream {
         let mut o = Object::new(Arc::new(self.backend.clone()), path);
         let meta = o.metadata_mut();
         meta.set_path(path)
-            .set_mode(ObjectMode::FILE)
+            .set_mode({
+                if path.ends_with('/') {
+                    ObjectMode::DIR
+                } else {
+                    ObjectMode::FILE
+                }
+            })
             .set_content_length(bs.len() as u64)
             .set_complete();
 

--- a/tests/behavior/behavior.rs
+++ b/tests/behavior/behavior.rs
@@ -44,7 +44,9 @@ macro_rules! behavior_tests {
 
                 test_check,
                 test_metadata,
+                test_object_path,
                 test_object_id,
+                test_object_name,
 
                 test_create_file,
                 test_create_file_existing,
@@ -134,14 +136,40 @@ async fn test_metadata(op: Operator) -> Result<()> {
     Ok(())
 }
 
-/// Test object id and path.
+/// Test object id.
 async fn test_object_id(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let o = op.object(&path);
 
-    assert_eq!(o.path(), path);
     assert_eq!(o.id(), format!("{}{}", op.metadata().root(), path));
+
+    Ok(())
+}
+
+/// Test object path.
+async fn test_object_path(op: Operator) -> Result<()> {
+    let path = uuid::Uuid::new_v4().to_string();
+
+    let o = op.object(&path);
+
+    assert_eq!(o.path(), path);
+
+    Ok(())
+}
+
+/// Test object name.
+async fn test_object_name(op: Operator) -> Result<()> {
+    let path = uuid::Uuid::new_v4().to_string();
+
+    let o = op.object(&path);
+    assert_eq!(o.name(), path);
+
+    let name = uuid::Uuid::new_v4().to_string();
+    let path = format!("{}/{}", uuid::Uuid::new_v4(), name);
+
+    let o = op.object(&path);
+    assert_eq!(o.name(), name);
 
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(object): Make Metadata::name() return &str
