### PR TITLE
fix(services/s3,hdfs): List empty dir should not return itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["filesystem"]
 description = "Open Data Access Layer that connect the whole world together."
 edition = "2021"
+homepage = "https://opendal.databend.rs/"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 license = "Apache-2.0"
 name = "opendal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ anyhow = "1.0.56"
 async-compat = "0.2.1"
 # Temp workaround, should come back to tagged version after https://github.com/Nemo157/async-compression/issues/150 resolved.
 async-compression = { package = "async-compression-issue-150-workaround", version = "0.3.15-issue-150", features = [
-  "futures-io",
-  "all-algorithms",
+    "futures-io",
+    "all-algorithms",
 ], optional = true }
 async-trait = "0.1.53"
 backon = { version = "0.0.2", optional = true }
@@ -44,7 +44,7 @@ base64 = "0.13.0"
 bytes = "1.1.0"
 dotenv = { version = "0.15.0", optional = true }
 futures = { version = "0.3.21", features = ["alloc"] }
-hdrs = { version = "0.1.3", optional = true, features = ["futures-io"] }
+hdrs = { version = "0.1.4", optional = true, features = ["futures-io"] }
 http = "0.2.6"
 hyper = { version = "0.14.18", features = ["full"] }
 hyper-tls = "0.5.0"
@@ -67,9 +67,9 @@ uuid = { version = "1.0.0", optional = true, features = ["serde", "v4"] }
 anyhow = "1.0.56"
 cfg-if = "1.0.0"
 criterion = { version = "0.3.5", features = [
-  "async",
-  "async_tokio",
-  "html_reports",
+    "async",
+    "async_tokio",
+    "html_reports",
 ] }
 dotenv = "0.15.0"
 env_logger = "0.9.0"

--- a/src/object.rs
+++ b/src/object.rs
@@ -824,7 +824,9 @@ impl Metadata {
     pub(crate) fn set_mode(&mut self, mode: ObjectMode) -> &mut Self {
         debug_assert!(
             (mode == ObjectMode::DIR) == self.path.ends_with('/'),
-            "mode must match with path"
+            "mode {:?} not match with path {}",
+            mode,
+            self.path
         );
 
         self.mode = Some(mode);

--- a/src/services/azblob/object_stream.rs
+++ b/src/services/azblob/object_stream.rs
@@ -133,9 +133,16 @@ impl futures::Stream for AzblobObjectStream {
                 };
 
                 let objects = &output.blobs.blob;
-                if *objects_idx < objects.len() {
+                while *objects_idx < objects.len() {
+                    let object = &objects[*objects_idx];
                     *objects_idx += 1;
-                    let object = &objects[*objects_idx - 1];
+
+                    // azblob could return the dir itself in contents
+                    // which endswith `/`.
+                    // We should ignore them.
+                    if object.name.ends_with('/') {
+                        continue;
+                    }
 
                     let mut o = Object::new(
                         Arc::new(backend.clone()),

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -172,7 +172,10 @@ impl Backend {
             return self.root.clone();
         }
 
-        format!("{}{}", &self.root, path.trim_start_matches('/'))
+        PathBuf::from(&self.root)
+            .join(path)
+            .to_string_lossy()
+            .to_string()
     }
 }
 
@@ -222,7 +225,7 @@ impl Accessor for Backend {
                         e
                     })?;
 
-                debug!("object {path} create file");
+                debug!("object {path} created file");
                 Ok(())
             }
             ObjectMode::DIR => {
@@ -232,7 +235,7 @@ impl Accessor for Backend {
                     e
                 })?;
 
-                debug!("object {path} create dir");
+                debug!("object {path} created dir");
                 Ok(())
             }
             ObjectMode::Unknown => unreachable!(),

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -226,6 +226,7 @@ impl Accessor for Backend {
                         e
                     })?;
 
+                debug!("object {path} create file");
                 Ok(())
             }
             ObjectMode::DIR => {
@@ -235,6 +236,7 @@ impl Accessor for Backend {
                     e
                 })?;
 
+                debug!("object {path} create dir");
                 Ok(())
             }
             ObjectMode::Unknown => unreachable!(),

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -172,11 +172,7 @@ impl Backend {
             return self.root.clone();
         }
 
-        if path.starts_with('/') {
-            format!("{}{}", &self.root, path)
-        } else {
-            format!("{}/{}", &self.root, path)
-        }
+        format!("{}{}", &self.root, path.trim_start_matches('/'))
     }
 }
 

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -210,7 +210,7 @@ impl Accessor for Backend {
         let paths = map
             .iter()
             .map(|(k, _)| k.clone())
-            .filter(|k| k.starts_with(&path))
+            .filter(|k| k.starts_with(&path) && k != &path)
             .collect::<Vec<String>>();
 
         Ok(Box::new(EntryStream {

--- a/src/services/s3/object_stream.rs
+++ b/src/services/s3/object_stream.rs
@@ -157,8 +157,8 @@ impl futures::Stream for S3ObjectStream {
                     let object = &objects[*objects_idx];
                     *objects_idx += 1;
 
-                    // If minio deployed on local fs, it could return the
-                    // dir itself in contents which endswith `/`.
+                    // s3 could return the dir itself in contents
+                    // which endswith `/`.
                     // We should ignore them.
                     if object.key.ends_with('/') {
                         continue;

--- a/src/services/s3/object_stream.rs
+++ b/src/services/s3/object_stream.rs
@@ -153,9 +153,16 @@ impl futures::Stream for S3ObjectStream {
                 }
 
                 let objects = &output.contents;
-                if *objects_idx < objects.len() {
+                while *objects_idx < objects.len() {
+                    let object = &objects[*objects_idx];
                     *objects_idx += 1;
-                    let object = &objects[*objects_idx - 1];
+
+                    // If minio deployed on local fs, it could return the
+                    // dir itself in contents which endswith `/`.
+                    // We should ignore them.
+                    if object.key.ends_with('/') {
+                        continue;
+                    }
 
                     let mut o = Object::new(
                         Arc::new(backend.clone()),


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(s3): List empty dir could return itself
