### PR TITLE
keep hdfs path unmodified

### DIFF
--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -114,6 +114,11 @@ pub trait Accessor: Send + Sync + Debug {
         let _ = args;
         unimplemented!()
     }
+
+    /// for hdfs accessor, should not normalize the path, it may use hdfs://127.0.0.1:9000/xx path pattern 
+    fn should_normalize_path(&self) -> bool {
+        return true;
+    }
 }
 
 /// All functions in `Accessor` only requires `&self`, so it's safe to implement

--- a/src/object.rs
+++ b/src/object.rs
@@ -55,10 +55,16 @@ impl Object {
     /// - Path endswith `/` means it's a dir path.
     /// - Otherwise, it's a file path.
     pub fn new(acc: Arc<dyn Accessor>, path: &str) -> Self {
+        let path = if acc.should_normalize_path() {
+           Object::normalize_path(path) 
+        } else {
+            path.to_string()
+        };
+
         Self {
             acc,
             meta: Metadata {
-                path: Object::normalize_path(path),
+                path,
                 ..Default::default()
             },
         }
@@ -822,11 +828,6 @@ impl Metadata {
     }
 
     pub(crate) fn set_mode(&mut self, mode: ObjectMode) -> &mut Self {
-        debug_assert!(
-            (mode == ObjectMode::DIR) == self.path.ends_with('/'),
-            "mode must match with path"
-        );
-
         self.mode = Some(mode);
         self
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

for now  hdfs accessor list and read failed, the main reason is  hdfs path pattern related logic,  so suggest to remove hdfs root config, keep hdfs path as it is.   
there are some diff between HDFS and S3:
1,  hdfs does't support relative path, we just use absolute path
2,  dir path does't end with '/'