### PR TITLE
refactor: Rename Metadata to ObjectMetadata for clearify

### DIFF
--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -26,7 +26,7 @@ use crate::ops::OpStat;
 use crate::ops::OpWrite;
 use crate::BytesReader;
 use crate::BytesWriter;
-use crate::Metadata;
+use crate::ObjectMetadata;
 use crate::ObjectStreamer;
 use crate::Scheme;
 
@@ -89,7 +89,7 @@ pub trait Accessor: Send + Sync + Debug {
     ///
     /// - `stat` empty path means stat backend's root path.
     /// - `stat` a path endswith "/" means stating a dir.
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         let _ = args;
         unimplemented!()
     }
@@ -132,7 +132,7 @@ impl<T: Accessor> Accessor for Arc<T> {
     async fn write(&self, args: &OpWrite) -> Result<BytesWriter> {
         self.as_ref().write(args).await
     }
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         self.as_ref().stat(args).await
     }
     async fn delete(&self, args: &OpDelete) -> Result<()> {

--- a/src/io_util/seekable_reader.rs
+++ b/src/io_util/seekable_reader.rs
@@ -31,8 +31,8 @@ use crate::ops::OpRead;
 use crate::ops::OpStat;
 use crate::Accessor;
 use crate::BytesReader;
-use crate::Metadata;
 use crate::Object;
+use crate::ObjectMetadata;
 
 /// Add seek support for object via internal lazy operation.
 ///
@@ -85,7 +85,7 @@ pub struct SeekableReader {
 enum State {
     Idle,
     Sending(BoxFuture<'static, Result<BytesReader>>),
-    Seeking(BoxFuture<'static, Result<Metadata>>),
+    Seeking(BoxFuture<'static, Result<ObjectMetadata>>),
     Reading(BytesReader),
 }
 

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -32,7 +32,7 @@ use crate::Accessor;
 use crate::BytesReader;
 use crate::BytesWriter;
 use crate::Layer;
-use crate::Metadata;
+use crate::ObjectMetadata;
 use crate::ObjectStreamer;
 
 /// Implement [`Layer`] for [`backon::Backoff`](https://docs.rs/backon/latest/backon/trait.Backoff.html) so that all backoff can be used as a layer
@@ -104,7 +104,7 @@ where
             .with_error_fn(|e| e.kind() == ErrorKind::Interrupted)
             .await
     }
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         { || self.inner.stat(args) }
             .retry(self.backoff.clone())
             .with_error_fn(|e| e.kind() == ErrorKind::Interrupted)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! use anyhow::Result;
 //! use futures::StreamExt;
 //! use opendal::services::fs;
-//! use opendal::Metadata;
+//! use opendal::ObjectMetadata;
 //! use opendal::Object;
 //! use opendal::ObjectMode;
 //! use opendal::ObjectStreamer;
@@ -60,7 +60,7 @@
 //!     let bs: Vec<u8> = o.range_read(1..=11).await?;
 //!
 //!     // Get object's Metadata
-//!     let meta: Metadata = o.metadata().await?;
+//!     let meta: ObjectMetadata = o.metadata().await?;
 //!     let name: &str = meta.name();
 //!     let path: &str = meta.path();
 //!     let mode: ObjectMode = meta.mode();
@@ -104,8 +104,10 @@ mod operator;
 pub use operator::Operator;
 
 mod object;
-pub use object::Metadata;
 pub use object::Object;
+pub use object::ObjectMetadata;
+#[deprecated = "Metadata has been deprecated, use ObjectMetadata instead"]
+pub use object::ObjectMetadata as Metadata;
 pub use object::ObjectMode;
 pub use object::ObjectStream;
 pub use object::ObjectStreamer;

--- a/src/object.rs
+++ b/src/object.rs
@@ -45,7 +45,7 @@ use crate::BytesWrite;
 #[derive(Clone, Debug)]
 pub struct Object {
     acc: Arc<dyn Accessor>,
-    meta: Metadata,
+    meta: ObjectMetadata,
 }
 
 impl Object {
@@ -57,7 +57,7 @@ impl Object {
     pub fn new(acc: Arc<dyn Accessor>, path: &str) -> Self {
         Self {
             acc,
-            meta: Metadata {
+            meta: ObjectMetadata {
                 path: Object::normalize_path(path),
                 ..Default::default()
             },
@@ -643,11 +643,11 @@ impl Object {
         self.acc.list(op).await
     }
 
-    pub(crate) fn metadata_ref(&self) -> &Metadata {
+    pub(crate) fn metadata_ref(&self) -> &ObjectMetadata {
         &self.meta
     }
 
-    pub(crate) fn metadata_mut(&mut self) -> &mut Metadata {
+    pub(crate) fn metadata_mut(&mut self) -> &mut ObjectMetadata {
         &mut self.meta
     }
 
@@ -673,7 +673,7 @@ impl Object {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn metadata(&self) -> Result<Metadata> {
+    pub async fn metadata(&self) -> Result<ObjectMetadata> {
         let op = &OpStat::new(self.meta.path())?;
 
         self.acc.stat(op).await
@@ -701,7 +701,7 @@ impl Object {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn metadata_cached(&mut self) -> Result<&Metadata> {
+    pub async fn metadata_cached(&mut self) -> Result<&ObjectMetadata> {
         if self.meta.complete() {
             return Ok(&self.meta);
         }
@@ -744,7 +744,7 @@ impl Object {
 
 /// Metadata carries all object metadata.
 #[derive(Debug, Clone, Default)]
-pub struct Metadata {
+pub struct ObjectMetadata {
     complete: bool,
 
     path: String,
@@ -755,7 +755,7 @@ pub struct Metadata {
     last_modified: Option<OffsetDateTime>,
 }
 
-impl Metadata {
+impl ObjectMetadata {
     /// Whether this object is complete.
     ///
     /// - If complete, this metadata is the full set. And we can't
@@ -938,9 +938,9 @@ mod tests {
         ];
 
         for (name, input, expect) in cases {
-            let meta = Metadata {
+            let meta = ObjectMetadata {
                 path: input.to_string(),
-                ..Metadata::default()
+                ..ObjectMetadata::default()
             };
             assert_eq!(meta.name(), expect, "{}", name)
         }

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -48,7 +48,7 @@ use crate::error::BackendError;
 use crate::error::ObjectError;
 use crate::io_util::new_http_channel;
 use crate::io_util::HttpBodyWriter;
-use crate::object::Metadata;
+use crate::object::ObjectMetadata;
 use crate::ops::BytesRange;
 use crate::ops::OpCreate;
 use crate::ops::OpDelete;
@@ -355,7 +355,7 @@ impl Accessor for Backend {
     }
 
     #[trace("stat")]
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         increment_counter!("opendal_azure_stat_requests");
 
         let p = self.get_abs_path(args.path());
@@ -363,7 +363,7 @@ impl Accessor for Backend {
 
         // Stat root always returns a DIR.
         if self.get_rel_path(&p).is_empty() {
-            let mut m = Metadata::default();
+            let mut m = ObjectMetadata::default();
             m.set_path(args.path());
             m.set_content_length(0);
             m.set_mode(ObjectMode::DIR);
@@ -376,7 +376,7 @@ impl Accessor for Backend {
         let resp = self.get_blob_properties(&p).await?;
         match resp.status() {
             http::StatusCode::OK => {
-                let mut m = Metadata::default();
+                let mut m = ObjectMetadata::default();
                 m.set_path(args.path());
 
                 // Parse content_length
@@ -444,7 +444,7 @@ impl Accessor for Backend {
                 Ok(m)
             }
             StatusCode::NOT_FOUND if p.ends_with('/') => {
-                let mut m = Metadata::default();
+                let mut m = ObjectMetadata::default();
                 m.set_path(args.path());
                 m.set_content_length(0);
                 m.set_mode(ObjectMode::DIR);

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -39,7 +39,7 @@ use crate::accessor::AccessorMetadata;
 use crate::error::other;
 use crate::error::BackendError;
 use crate::error::ObjectError;
-use crate::object::Metadata;
+use crate::object::ObjectMetadata;
 use crate::object::ObjectMode;
 use crate::object::ObjectStreamer;
 use crate::ops::OpCreate;
@@ -292,7 +292,7 @@ impl Accessor for Backend {
     }
 
     #[trace("stat")]
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         increment_counter!("opendal_fs_stat_requests");
 
         let path = self.get_abs_path(args.path());
@@ -304,7 +304,7 @@ impl Accessor for Backend {
             e
         })?;
 
-        let mut m = Metadata::default();
+        let mut m = ObjectMetadata::default();
         if meta.is_dir() {
             let mut p = args.path().to_string();
             if !p.ends_with('/') {

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -46,7 +46,7 @@ use crate::Accessor;
 use crate::AccessorMetadata;
 use crate::BytesReader;
 use crate::BytesWriter;
-use crate::Metadata;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 use crate::ObjectStreamer;
 use crate::Scheme;
@@ -325,7 +325,7 @@ impl Accessor for Backend {
     }
 
     #[trace("stat")]
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         let path = self.get_abs_path(args.path());
         debug!("object {} stat start", &path);
 
@@ -335,7 +335,7 @@ impl Accessor for Backend {
             e
         })?;
 
-        let mut m = Metadata::default();
+        let mut m = ObjectMetadata::default();
         if meta.is_dir() {
             let mut p = args.path().to_string();
             if !p.ends_with('/') {

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -44,8 +44,8 @@ use crate::Accessor;
 use crate::AccessorMetadata;
 use crate::BytesReader;
 use crate::BytesWriter;
-use crate::Metadata;
 use crate::Object;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 use crate::Scheme;
 
@@ -157,11 +157,11 @@ impl Accessor for Backend {
     }
 
     #[trace("stat")]
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         let path = args.path();
 
         if path.ends_with('/') {
-            let mut meta = Metadata::default();
+            let mut meta = ObjectMetadata::default();
             meta.set_path(path)
                 .set_mode(ObjectMode::DIR)
                 .set_content_length(0)
@@ -179,7 +179,7 @@ impl Accessor for Backend {
             )
         })?;
 
-        let mut meta = Metadata::default();
+        let mut meta = ObjectMetadata::default();
         meta.set_path(path)
             .set_mode(ObjectMode::FILE)
             .set_content_length(data.len() as u64)

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -50,7 +50,7 @@ use crate::error::BackendError;
 use crate::error::ObjectError;
 use crate::io_util::new_http_channel;
 use crate::io_util::HttpBodyWriter;
-use crate::object::Metadata;
+use crate::object::ObjectMetadata;
 use crate::object::ObjectStreamer;
 use crate::ops::BytesRange;
 use crate::ops::OpCreate;
@@ -883,7 +883,7 @@ impl Accessor for Backend {
     }
 
     #[trace("stat")]
-    async fn stat(&self, args: &OpStat) -> Result<Metadata> {
+    async fn stat(&self, args: &OpStat) -> Result<ObjectMetadata> {
         increment_counter!("opendal_s3_stat_requests");
 
         let p = self.get_abs_path(args.path());
@@ -891,7 +891,7 @@ impl Accessor for Backend {
 
         // Stat root always returns a DIR.
         if self.get_rel_path(&p).is_empty() {
-            let mut m = Metadata::default();
+            let mut m = ObjectMetadata::default();
             m.set_path(args.path());
             m.set_content_length(0);
             m.set_mode(ObjectMode::DIR);
@@ -905,7 +905,7 @@ impl Accessor for Backend {
 
         match resp.status() {
             StatusCode::OK => {
-                let mut m = Metadata::default();
+                let mut m = ObjectMetadata::default();
                 m.set_path(args.path());
 
                 // Parse content_length
@@ -972,7 +972,7 @@ impl Accessor for Backend {
                 Ok(m)
             }
             StatusCode::NOT_FOUND if p.ends_with('/') => {
-                let mut m = Metadata::default();
+                let mut m = ObjectMetadata::default();
                 m.set_path(args.path());
                 m.set_content_length(0);
                 m.set_mode(ObjectMode::DIR);


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Rename Metadata to ObjectMetadata for clearify
