### PR TITLE
Upgrade dev-dependency `size` to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,6 @@ paste = "1.0.7"
 rand = "0.8.5"
 serde_json = "1.0.79"
 sha2 = "0.10.2"
-size = "0.2.0"
+size = "0.4.0"
 uuid = { version = "1.0.0", features = ["serde", "v4"] }
 wiremock = "0.5.13"

--- a/benches/ops/read.rs
+++ b/benches/ops/read.rs
@@ -16,9 +16,7 @@ use futures::io;
 use futures::AsyncReadExt;
 use opendal::Operator;
 use rand::prelude::*;
-use size::Base;
 use size::Size;
-use size::Style;
 
 use super::utils::*;
 
@@ -43,10 +41,10 @@ fn bench_read_full(c: &mut Criterion, op: Operator) {
     let mut rng = thread_rng();
 
     for size in [
-        Size::Kibibytes(4_usize),
-        Size::Kibibytes(256),
-        Size::Mebibytes(4),
-        Size::Mebibytes(16),
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
     ] {
         let content = gen_bytes(&mut rng, size.bytes() as usize);
         let path = uuid::Uuid::new_v4().to_string();
@@ -54,7 +52,7 @@ fn bench_read_full(c: &mut Criterion, op: Operator) {
 
         group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
         group.bench_with_input(
-            size.to_string(Base::Base2, Style::Abbreviated),
+            size.to_string(),
             &(op.clone(), &path),
             |b, (op, path)| {
                 b.to_async(&*TOKIO).iter(|| async {
@@ -81,10 +79,10 @@ fn bench_read_part(c: &mut Criterion, op: Operator) {
     let mut rng = thread_rng();
 
     for size in [
-        Size::Kibibytes(4_usize),
-        Size::Kibibytes(256),
-        Size::Mebibytes(4),
-        Size::Mebibytes(16),
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
     ] {
         let content = gen_bytes(&mut rng, (size.bytes() * 2) as usize);
         let path = uuid::Uuid::new_v4().to_string();
@@ -93,7 +91,7 @@ fn bench_read_part(c: &mut Criterion, op: Operator) {
 
         group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
         group.bench_with_input(
-            size.to_string(Base::Base2, Style::Abbreviated),
+            size.to_string(),
             &(op.clone(), &path),
             |b, (op, path)| {
                 b.to_async(&*TOKIO).iter(|| async {
@@ -115,10 +113,10 @@ fn bench_read_parallel(c: &mut Criterion, op: Operator) {
     let mut rng = thread_rng();
 
     for size in [
-        Size::Kibibytes(4_usize),
-        Size::Kibibytes(256),
-        Size::Mebibytes(4),
-        Size::Mebibytes(16),
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
     ] {
         let content = gen_bytes(&mut rng, (size.bytes() * 2) as usize);
         let path = uuid::Uuid::new_v4().to_string();
@@ -132,7 +130,7 @@ fn bench_read_parallel(c: &mut Criterion, op: Operator) {
                 format!(
                     "{}x{}",
                     parallel,
-                    size.to_string(Base::Base2, Style::Abbreviated)
+                    size.to_string()
                 ),
                 &(op.clone(), &path, buf.clone()),
                 |b, (op, path, buf)| {

--- a/benches/ops/write.rs
+++ b/benches/ops/write.rs
@@ -14,9 +14,7 @@
 use criterion::Criterion;
 use opendal::Operator;
 use rand::prelude::*;
-use size::Base;
 use size::Size;
-use size::Style;
 
 use super::utils::*;
 
@@ -39,10 +37,10 @@ fn bench_write_once(c: &mut Criterion, op: Operator) {
     let mut rng = thread_rng();
 
     for size in [
-        Size::Kibibytes(4_usize),
-        Size::Kibibytes(256),
-        Size::Mebibytes(4),
-        Size::Mebibytes(16),
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
     ] {
         let content = gen_bytes(&mut rng, size.bytes() as usize);
         let path = uuid::Uuid::new_v4().to_string();
@@ -50,7 +48,7 @@ fn bench_write_once(c: &mut Criterion, op: Operator) {
 
         group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
         group.bench_with_input(
-            size.to_string(Base::Base2, Style::Abbreviated),
+            size.to_string(),
             &(op.clone(), &path, content),
             |b, (op, path, content)| {
                 b.to_async(&*TOKIO).iter(|| async {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This simplifies the formatting code and removes the old transitive dependencies
of `size` 0.2 (as `size` 0.4 is dependency-free).

It was previously required to explicitly specify the base and unit display style
despite the previous values matching `Size::to_string()`'s defaults (base-2
units and abbreviated names).

Closes #391 