### PR TITLE
feat: BytesRange supports parsing from range and content-range

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -19,7 +19,9 @@
 use std::collections::Bound;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::io::{Error, ErrorKind, Result};
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
 use std::ops::RangeBounds;
 
 use anyhow::anyhow;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -19,7 +19,7 @@
 use std::collections::Bound;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 use std::ops::RangeBounds;
 
 use anyhow::anyhow;
@@ -399,6 +399,13 @@ impl BytesRange {
     /// Create a new `BytesRange`
     ///
     /// It better to use `BytesRange::from(1024..2048)` to construct.
+    ///
+    /// # Note
+    ///
+    /// The behavior for `None` and `Some(0)` is different.
+    ///
+    /// - offset=None => `bytes=-<size>`
+    /// - offset=Some(0) => `bytes=0-<size>`
     pub fn new(offset: Option<u64>, size: Option<u64>) -> Self {
         BytesRange(offset, size)
     }
@@ -412,17 +419,120 @@ impl BytesRange {
     pub fn size(&self) -> Option<u64> {
         self.1
     }
+
+    /// Parse header Range into BytesRange
+    ///
+    /// NOTE: we don't support multi range.
+    ///
+    /// Range: <unit>=<range-start>-
+    /// Range: <unit>=<range-start>-<range-end>
+    /// Range: <unit>=-<suffix-length>
+    pub fn from_header_range(s: &str) -> Result<Self> {
+        let s = s.to_lowercase();
+        let s = s.strip_prefix("range: bytes=").ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range is invalid: {s}"),
+            )
+        })?;
+
+        if s.contains(',') {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range should not contain multiple ranges: {s}"),
+            ));
+        }
+
+        let v = s.split('-').collect::<Vec<_>>();
+        if v.len() != 2 {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range should not contain multiple ranges: {s}"),
+            ));
+        }
+
+        let parse_int_error = |e: std::num::ParseIntError| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range must contain valid integer: {e}"),
+            )
+        };
+
+        if v[1].is_empty() {
+            // <range-start>-
+            Ok(BytesRange::new(
+                Some(v[0].parse().map_err(parse_int_error)?),
+                None,
+            ))
+        } else if v[0].is_empty() {
+            // -<suffix-length>
+            Ok(BytesRange::new(
+                None,
+                Some(v[1].parse::<u64>().map_err(parse_int_error)? + 1),
+            ))
+        } else {
+            // <range-start>-<range-end>
+            let start: u64 = v[0].parse().map_err(parse_int_error)?;
+            let end: u64 = v[1].parse().map_err(parse_int_error)?;
+            Ok(BytesRange::new(Some(start), Some(end - start + 1)))
+        }
+    }
+
+    /// Parse header Content-Range into BytesRange
+    ///
+    /// Content-Range: <unit> <range-start>-<range-end>/<size>
+    /// Content-Range: <unit> <range-start>-<range-end>/*
+    /// Content-Range: <unit> */<size>
+    pub fn from_header_content_range(s: &str) -> Result<Self> {
+        let s = s.to_lowercase();
+        let s = s.strip_prefix("content-range: bytes ").ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header content range is invalid: {s}"),
+            )
+        })?;
+
+        let parse_int_error = |e: std::num::ParseIntError| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range must contain valid integer: {e}"),
+            )
+        };
+
+        if let Some(size) = s.strip_prefix("*/") {
+            return Ok(BytesRange::new(
+                Some(0),
+                Some(size.parse().map_err(parse_int_error)?),
+            ));
+        }
+
+        // We don't care about the total size in content-range.
+        let s = s
+            .get(..s.find('/').expect("content-range must have /"))
+            .expect("content-range must has /");
+        let v = s.split('-').collect::<Vec<_>>();
+        if v.len() != 2 {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                anyhow!("header range should not contain multiple ranges: {s}"),
+            ));
+        }
+
+        let start: u64 = v[0].parse().map_err(parse_int_error)?;
+        let end: u64 = v[1].parse().map_err(parse_int_error)?;
+        Ok(BytesRange::new(Some(start), Some(end - start + 1)))
+    }
 }
 
 impl ToString for BytesRange {
     // # NOTE
     //
-    // - `bytes=-1023` means get the suffix of the file, we must set the start to 0.
+    // - `bytes=-1023` means get the suffix of the file.
     // - `bytes=0-1023` means get the first 1024 bytes, we must set the end to 1023.
     fn to_string(&self) -> String {
         match (self.0, self.1) {
             (Some(offset), None) => format!("bytes={}-", offset),
-            (None, Some(size)) => format!("bytes=0-{}", size - 1),
+            (None, Some(size)) => format!("bytes=-{}", size - 1),
             (Some(offset), Some(size)) => format!("bytes={}-{}", offset, offset + size - 1),
             _ => panic!("invalid range"),
         }
@@ -437,7 +547,8 @@ where
         let offset = match range.start_bound().cloned() {
             Bound::Included(n) => Some(n),
             Bound::Excluded(n) => Some(n + 1),
-            Bound::Unbounded => None,
+            // Note: RangeBounds `..x` means `0..x`, it's different from `bytes=..x`
+            Bound::Unbounded => Some(0),
         };
         let size = match range.end_bound().cloned() {
             Bound::Included(n) => Some(n + 1 - offset.unwrap_or_default()),
@@ -456,6 +567,9 @@ mod tests {
     #[test]
     fn test_bytes_range_to_string() {
         let h = BytesRange::new(None, Some(1024));
+        assert_eq!(h.to_string(), "bytes=-1023");
+
+        let h = BytesRange::new(Some(0), Some(1024));
         assert_eq!(h.to_string(), "bytes=0-1023");
 
         let h = BytesRange::new(Some(1024), None);
@@ -467,13 +581,81 @@ mod tests {
 
     #[test]
     fn test_bytes_range_from_range_bounds() {
-        assert_eq!(BytesRange::new(None, None), BytesRange::from(..));
+        assert_eq!(BytesRange::new(Some(0), None), BytesRange::from(..));
         assert_eq!(BytesRange::new(Some(10), None), BytesRange::from(10..));
-        assert_eq!(BytesRange::new(None, Some(11)), BytesRange::from(..=10));
-        assert_eq!(BytesRange::new(None, Some(10)), BytesRange::from(..10));
+        assert_eq!(BytesRange::new(Some(0), Some(11)), BytesRange::from(..=10));
+        assert_eq!(BytesRange::new(Some(0), Some(10)), BytesRange::from(..10));
         assert_eq!(
             BytesRange::new(Some(10), Some(10)),
             BytesRange::from(10..20)
         );
+    }
+
+    #[test]
+    fn test_bytes_range_from_header_range() -> Result<()> {
+        let cases = vec![
+            (
+                "range-start",
+                "Range: bytes=123-",
+                BytesRange::new(Some(123), None),
+            ),
+            (
+                "suffix",
+                "Range: bytes=-123",
+                BytesRange::new(None, Some(124)),
+            ),
+            (
+                "range",
+                "Range: bytes=123-124",
+                BytesRange::new(Some(123), Some(2)),
+            ),
+            (
+                "one byte",
+                "Range: bytes=0-0",
+                BytesRange::new(Some(0), Some(1)),
+            ),
+            (
+                "lower case header",
+                "range: bytes=0-0",
+                BytesRange::new(Some(0), Some(1)),
+            ),
+        ];
+
+        for (name, input, expected) in cases {
+            let actual = BytesRange::from_header_range(input)?;
+
+            assert_eq!(expected, actual, "{name}")
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bytes_range_from_header_content_range() -> Result<()> {
+        let cases = vec![
+            (
+                "range start with unknown size",
+                "Content-Range: bytes 123-123/*",
+                BytesRange::new(Some(123), Some(1)),
+            ),
+            (
+                "range start with known size",
+                "Content-Range: bytes 123-123/1",
+                BytesRange::new(Some(123), Some(1)),
+            ),
+            (
+                "only have size",
+                "Content-Range: bytes */1024",
+                BytesRange::new(Some(0), Some(1024)),
+            ),
+        ];
+
+        for (name, input, expected) in cases {
+            let actual = BytesRange::from_header_content_range(input)?;
+
+            assert_eq!(expected, actual, "{name}")
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: BytesRange supports parsing from range and content-range

Fix #446 
