### PR TITLE
fix: Disable connection pool as workaround for async runtime hang

### DIFF
--- a/src/io_util/http_client.rs
+++ b/src/io_util/http_client.rs
@@ -30,7 +30,14 @@ pub struct HttpClient(
 impl HttpClient {
     /// Create a new http client.
     pub fn new() -> Self {
-        HttpClient(hyper::Client::builder().build(hyper_tls::HttpsConnector::new()))
+        HttpClient(
+            hyper::Client::builder()
+                // Disable connection pool to address weired async runtime hang.
+                //
+                // ref: https://github.com/datafuselabs/opendal/issues/473
+                .pool_max_idle_per_host(0)
+                .build(hyper_tls::HttpsConnector::new()),
+        )
     }
 }
 

--- a/src/io_util/http_client.rs
+++ b/src/io_util/http_client.rs
@@ -32,7 +32,7 @@ impl HttpClient {
     pub fn new() -> Self {
         HttpClient(
             hyper::Client::builder()
-                // Disable connection pool to address weired async runtime hang.
+                // Disable connection pool to address weird async runtime hang.
                 //
                 // ref: https://github.com/datafuselabs/opendal/issues/473
                 .pool_max_idle_per_host(0)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Related to https://github.com/datafuselabs/opendal/issues/473
