### PR TITLE
fix(services/s3): If input range is `0..`, don't insert range header

### DIFF
--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -1160,7 +1160,7 @@ impl Backend {
 
         let mut req = isahc::Request::get(&url);
 
-        if offset.is_some() || size.is_some() {
+        if offset.unwrap_or_default() != 0 || size.is_some() {
             req = req.header(
                 http::header::RANGE,
                 BytesRange::new(offset, size).to_string(),


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/s3): If input range is `0..`, don't insert range header
