### PR TITLE
feat: add logging utilities for Reader

### DIFF
--- a/src/layers/logging.rs
+++ b/src/layers/logging.rs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 use std::fmt::Debug;
-use std::io::ErrorKind;
 use std::io::Result;
+use std::io::{ErrorKind, IoSliceMut};
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use async_trait::async_trait;
+use futures::AsyncRead;
 use log::debug;
 use log::error;
 use log::warn;
@@ -36,13 +39,13 @@ use crate::ops::OpWrite;
 use crate::ops::OpWriteMultipart;
 use crate::ops::Operation;
 use crate::ops::PresignedRequest;
-use crate::Accessor;
 use crate::AccessorMetadata;
 use crate::BytesReader;
 use crate::DirStreamer;
 use crate::Layer;
 use crate::ObjectMetadata;
 use crate::Scheme;
+use crate::{Accessor, BytesRead};
 
 /// LoggingLayer will add logging for OpenDAL.
 ///
@@ -82,6 +85,70 @@ impl Layer for LoggingLayer {
         Arc::new(LoggingAccessor {
             scheme: meta.scheme(),
             inner,
+        })
+    }
+}
+trait A: Send + Unpin + AsyncRead{}
+
+pub struct LoggingReader {
+    scheme: Scheme,
+    path: String,
+    offset: Option<u64>,
+    have_read: usize,
+    to_read: Option<u64>,
+    inner: BytesReader
+}
+
+impl A for LoggingReader {}
+
+impl LoggingReader {
+    pub(crate) fn new(scheme: Scheme, args: &OpRead, reader: BytesReader) -> Self {
+        let path = args.path().to_string();
+        let offset = args.offset();
+        let size = args.size();
+        Self {
+            scheme,
+            path,
+            offset,
+            have_read: 0,
+            to_read: size,
+            inner: reader
+        }
+    }
+}
+
+impl AsyncRead for LoggingReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize>> {
+        Pin::new(&mut (*self.inner)).poll_read(cx, buf).map(|r|{
+            if let Ok(r) = r {
+                self.have_read += r;
+            }
+            debug!(target: "opendal::services", "service={} operation={} path={} size={:?} have_read={} poll read -> got: {:?}", self.scheme, Operation::Read, self.path, self.to_read, self.have_read, r);
+            r
+        }).map_err(|e| {
+            error!(target: "opendal::services", "service={} operation={} path={} size={:?} have_read={} poll read -> errored: {:?}", self.scheme, Operation::Read, self.path, self.to_read, self.have_read, e);
+            e
+        })
+    }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<Result<usize>> {
+        Pin::new(&mut (*self.inner)).poll_read_vectored(cx, bufs).map(|r|{
+            if let Ok(r) = r {
+                self.have_read += r;
+            }
+            debug!(target: "opendal::services", "service={} operation={} path={} size={:?} have_read={} poll vectored -> got: {:?}", self.scheme, Operation::Read, self.path, self.to_read, self.have_read, r);
+            r
+        }).map_err(|e| {
+            error!(target: "opendal::services", "service={} operation={} path={} size={:?} have_read={} poll vectored -> errored: {:?}", self.scheme, Operation::Read, self.path, self.to_read, self.have_read, e);
+            e
         })
     }
 }
@@ -174,8 +241,15 @@ impl Accessor for LoggingAccessor {
             .map(|v| {
                 debug!(
                     target: "opendal::services",
-                    "service={} operation={} path={} offset={:?} size={:?} -> got reader", self.scheme, Operation::Read, args.path(),args.offset(),  args.size() );
-                v
+                    "service={} operation={} path={} offset={:?} size={:?} -> got reader",
+                    self.scheme,
+                    Operation::Read,
+                    args.path(),
+                    args.offset(),
+                    args.size()
+                );
+                let r =LoggingReader::new(self.scheme.clone(), args, v);
+                Box::new(r)
             })
             .map_err(|err| {
                 if err.kind() == ErrorKind::Other {


### PR DESCRIPTION
igned-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

A trail of implementing observability of logging for `BytesReader`.

### Problem Encountered

The self-defined structure (LoggingReader) cannot implement BytesRead automatically while being able to implement a demo trait requiring the same trait bounds.

Demo trait to validate trait bounds:
https://github.com/ClSlaid/opendal/blob/018b826bcecf1f279c8251cb6e183c9c9eb91a75/src/layers/logging.rs#L91

The Clippy complains:

```rust
 cargo clippy                                
    Checking opendal v0.14.0 (/home/cl/CLionProjects/opendal)
warning: unused import: `BytesRead`
  --> src/layers/logging.rs:48:23
   |
48 | use crate::{Accessor, BytesRead};
   |                       ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0308]: mismatched types
   --> src/layers/logging.rs:238:9
    |
238 | /         self.inner
239 | |             .read(args)
240 | |             .await
241 | |             .map(|v| {
...   |
264 | |                 err
265 | |             })
    | |______________^ expected trait object `dyn io::BytesRead`, found struct `layers::logging::LoggingReader`
    |
    = note: expected enum `std::result::Result<std::boxed::Box<(dyn io::BytesRead + 'static)>, _>`
               found enum `std::result::Result<std::boxed::Box<layers::logging::LoggingReader>, _>`
note: return type inferred to be `std::result::Result<std::boxed::Box<(dyn io::BytesRead + 'static)>, std::io::Error>` here
   --> src/layers/logging.rs:227:64
    |
227 |       async fn read(&self, args: &OpRead) -> Result<BytesReader> {
    |  ________________________________________________________________^
228 | |         debug!(
229 | |             target: "opendal::services",
230 | |             "service={} operation={} path={} offset={:?} size={:?} -> started",
...   |
265 | |             })
266 | |     }
    | |_____^

For more information about this error, try `rustc --explain E0308`.
warning: `opendal` (lib) generated 1 warning
error: could not compile `opendal` due to previous error; 1 warning emitted

```
