### PR TITLE
Finalize FTP read operation 

### DIFF
--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -29,6 +29,7 @@ use futures::AsyncReadExt;
 use log::info;
 use suppaftp::async_native_tls::TlsConnector;
 use suppaftp::list::File;
+use suppaftp::types::FileType;
 use suppaftp::FtpStream;
 use time::OffsetDateTime;
 
@@ -36,6 +37,7 @@ use super::dir_stream::DirStream;
 use super::dir_stream::ReadDir;
 use super::err::new_request_connection_err;
 use super::err::new_request_quit_err;
+use super::FtpReader;
 use crate::accessor::AccessorCapability;
 use crate::error::other;
 use crate::error::BackendError;
@@ -303,10 +305,10 @@ impl Accessor for Backend {
         })?;
 
         let r: BytesReader = match args.size() {
-            None => Box::new(data_stream),
-            Some(size) => Box::new(data_stream.take(size)),
-        };
+            None => Box::new(FtpReader::new(Box::new(data_stream), ftp_stream)),
 
+            Some(size) => Box::new(FtpReader::new(Box::new(data_stream.take(size)), ftp_stream)),
+        };
         Ok(r)
     }
 
@@ -488,6 +490,17 @@ impl Backend {
                 anyhow!("change root request: {e:?}"),
             ))
         })?;
+
+        ftp_stream
+            .transfer_type(FileType::Binary)
+            .await
+            .map_err(|e| {
+                other(ObjectError::new(
+                    op,
+                    &self.endpoint,
+                    anyhow!("transfer type request: {e:?}"),
+                ))
+            })?;
 
         Ok(ftp_stream)
     }

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -305,9 +305,13 @@ impl Accessor for Backend {
         })?;
 
         let r: BytesReader = match args.size() {
-            None => Box::new(FtpReader::new(Box::new(data_stream), ftp_stream)),
+            None => Box::new(FtpReader::new(Box::new(data_stream), ftp_stream, path)),
 
-            Some(size) => Box::new(FtpReader::new(Box::new(data_stream.take(size)), ftp_stream)),
+            Some(size) => Box::new(FtpReader::new(
+                Box::new(data_stream.take(size)),
+                ftp_stream,
+                path,
+            )),
         };
         Ok(r)
     }

--- a/src/services/ftp/mod.rs
+++ b/src/services/ftp/mod.rs
@@ -88,3 +88,5 @@ pub use backend::Backend;
 pub use backend::Builder;
 mod dir_stream;
 mod err;
+mod util;
+pub use util::FtpReader;

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -109,10 +109,10 @@ impl AsyncRead for FtpReader {
             // Finalize state, wait for finalization of stream. Change state to Eof or Error according to the result of fut.
             State::Finalize(fut) => match ready!(Pin::new(fut).poll_unpin(cx)) {
                 Ok(_) => {
-                    return Poll::Ready(Ok(0));
+                    Poll::Ready(Ok(0))
                 }
                 Err(e) => {
-                    return Poll::Ready(Err(Error::new(e.kind(), e.to_string())));
+                    Poll::Ready(Err(Error::new(e.kind(), e.to_string())))
                 }
             },
         }

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -1,6 +1,19 @@
-use futures::AsyncRead;
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use crate::BytesReader;
+use futures::AsyncRead;
 use std::io::Result;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -1,0 +1,64 @@
+use futures::AsyncRead;
+
+use crate::BytesReader;
+use std::io::Result;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use suppaftp::FtpStream;
+use suppaftp::Status;
+use tokio::sync::Mutex;
+use tokio::task;
+
+/// Wrapper for ftp data stream and command stream.
+pub struct FtpReader {
+    reader: BytesReader,
+    client: Arc<Mutex<FtpStream>>,
+}
+
+impl FtpReader {
+    /// Create an instance of FtpReader.
+    pub fn new(r: BytesReader, c: FtpStream) -> Self {
+        Self {
+            reader: r,
+            client: Arc::new(Mutex::new(c)),
+        }
+    }
+}
+
+impl AsyncRead for FtpReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize>> {
+        let result = Pin::new(&mut self.reader).poll_read(cx, buf);
+
+        // Drop data stream and close command stream when hit Error or EOF.
+        match result {
+            Poll::Ready(Err(_)) | Poll::Ready(Ok(0)) => {
+                let c = self.client.clone();
+
+                drop(self.reader.as_mut());
+
+                task::spawn(async move {
+                    let mut guard = c.lock().await;
+
+                    guard
+                        .read_response_in(&[
+                            Status::ClosingDataConnection,
+                            Status::RequestedFileActionOk,
+                        ])
+                        .await
+                        .unwrap();
+
+                    guard.quit().await.unwrap();
+                    drop(guard);
+                });
+            }
+            _ => (),
+        };
+
+        result
+    }
+}

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -108,12 +108,8 @@ impl AsyncRead for FtpReader {
             }
             // Finalize state, wait for finalization of stream. Change state to Eof or Error according to the result of fut.
             State::Finalize(fut) => match ready!(Pin::new(fut).poll_unpin(cx)) {
-                Ok(_) => {
-                    Poll::Ready(Ok(0))
-                }
-                Err(e) => {
-                    Poll::Ready(Err(Error::new(e.kind(), e.to_string())))
-                }
+                Ok(_) => Poll::Ready(Ok(0)),
+                Err(e) => Poll::Ready(Err(Error::new(e.kind(), e.to_string()))),
             },
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

Fix: #638 

## Summary
**"src/services/ftp/backend.rs"**:
Specify the transfer type to be bianry.

**"src/services/ftp/util.rs"**:
Create a struct wrapper `FtpReader` for ftp data stream and command stream. 
Implement `AsyncRead` trait for `FtpReader`. `poll_read()` will generate a **tokio task** that close both data stream and command stream when we hit `Err` or `EOF`(0-byte read). In other situations, it would just call the default `poll_read()` method of `reader` field.
**Note**: it only works under tokio runtime.

It is workable, but there might exist better solutions (I am reading through this [post](https://internals.rust-lang.org/t/asynchronous-destructors/11127) to find out if there exists a more elegant way to finalize the connection.)
Also, I cannot find a proper way to handle error within `tokio:spawn`. The `read_response_in()` and `quit()` functions would cause the tokio worker to be panicked once we get `Err` return value.
