### PR TITLE
feat: make rustls the default tls implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --features rustls
+        run: cargo build --no-default-features --features rustls
 
   build_all_features:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,6 @@ jobs:
       - name: Build
         run: cargo build
 
-  build_rustls:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --no-default-features --features rustls
-
   build_all_features:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -110,35 +99,6 @@ jobs:
 
       - name: Test
         run: cargo test --no-fail-fast --features compress,layers-all
-        env:
-          RUST_LOG: DEBUG
-          RUST_BACKTRACE: full
-          LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}
-
-  unit_rustls:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Checkout python env
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-      - name: Checkout java env
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: '11'
-      - name: Setup-hdfs env
-        uses: beyondstorage/setup-hdfs@master
-        with:
-          hdfs-version: "3.3.2"
-
-      - name: Test rustls
-        run: cargo test --no-fail-fast --features compress,layers-all,rustls
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,8 @@ version = "0.16.0"
 all-features = true
 
 [features]
-default = ["native-tls"]
 # Enable compress support so that users can decompress while reading.
 compress = ["async-compression"]
-# Native TLS implementation
-native-tls = [
-  "reqwest/native-tls"
-]
-# Enable rustls support.
-rustls = [
-  "reqwest/rustls-tls-native-roots",
-  "ureq/rustls-native-certs",
-]
 # Enable serde support.
 serde = ["time/serde"]
 
@@ -103,7 +93,7 @@ pin-project = "1.0"
 prost = { version = "0.11", optional = true }
 quick-xml = { version = "0.25", features = ["serialize", "overlapped-lists"] }
 reqsign = "0.4"
-reqwest = { version = "0.11", features = ["stream"], default-features = false }
+reqwest = { version = "0.11", features = ["stream", "rustls-tls-native-roots"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 suppaftp = { version = "4.4", features = ["async-secure"], optional = true }
@@ -111,7 +101,7 @@ thiserror = "1.0"
 time = "0.3"
 tokio = { version = "1.20", features = ["fs"] }
 tracing = { version = "0.1", optional = true }
-ureq = "2.5"
+ureq = { version = "2.5", features = ["rustls-native-certs"] }
 
 [dev-dependencies]
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,16 @@ version = "0.16.0"
 all-features = true
 
 [features]
+default = ["native-tls"]
 # Enable compress support so that users can decompress while reading.
 compress = ["async-compression"]
+# Native TLS implementation
+native-tls = [
+  "reqwest/native-tls"
+]
 # Enable rustls support.
 rustls = [
-  "reqwest/rustls-tls",
   "reqwest/rustls-tls-native-roots",
-  "ureq/rustls",
   "ureq/rustls-native-certs",
 ]
 # Enable serde support.
@@ -100,7 +103,7 @@ pin-project = "1.0"
 prost = { version = "0.11", optional = true }
 quick-xml = { version = "0.25", features = ["serialize", "overlapped-lists"] }
 reqsign = "0.4"
-reqwest = { version = "0.11", features = ["stream"] }
+reqwest = { version = "0.11", features = ["stream"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 suppaftp = { version = "4.4", features = ["async-secure"], optional = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

In the recent changes of switch hyper to reqwest/ureq, the rustls feature is broken for having openssl included. This patch rearranges our feature set, by:

- ~introducing `native-tls` feature that enabled by default, it uses openssl for reqwest (ureq has no openssl support unfortunately)~
- removing `rustls-tls` from `reqwest` because it's already included in `rustls-tls-native-roots`
- turning off default features for `reqwest` to avoid openssl dependencies when using `rustls`
