### PR TITLE
oli: Implement basic cp command

### DIFF
--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -35,6 +35,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compat"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -208,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +276,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +323,15 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -563,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,10 +792,12 @@ name = "oli"
 version = "0.17.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "env_logger",
  "log",
  "opendal",
+ "predicates",
  "tokio",
 ]
 
@@ -866,6 +935,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1052,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1284,6 +1389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1616,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -760,6 +760,8 @@ dependencies = [
  "env_logger",
  "log",
  "opendal",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -729,8 +729,6 @@ dependencies = [
  "env_logger",
  "log",
  "opendal",
- "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -702,6 +702,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +731,7 @@ dependencies = [
  "opendal",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1344,10 +1355,23 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "once_cell",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/oli/Cargo.toml
+++ b/oli/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4"
 opendal = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1.20", features = ["fs", "macros", "rt-multi-thread"] }
 
 # Please comment the following patch while releasing.
 [patch.crates-io]

--- a/oli/Cargo.toml
+++ b/oli/Cargo.toml
@@ -18,6 +18,10 @@ log = "0.4"
 opendal = "0.17"
 tokio = { version = "1.20", features = ["fs", "macros", "rt-multi-thread"] }
 
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "2.1"
+
 # Please comment the following patch while releasing.
 [patch.crates-io]
 opendal = { path = "../" }

--- a/oli/Cargo.toml
+++ b/oli/Cargo.toml
@@ -16,6 +16,8 @@ clap = { version = "3.2", features = ["cargo"] }
 env_logger = "0.9"
 log = "0.4"
 opendal = "0.16.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 # Please comment the following patch while releasing.
 [patch.crates-io]

--- a/oli/Cargo.toml
+++ b/oli/Cargo.toml
@@ -16,8 +16,6 @@ clap = { version = "3.2", features = ["cargo"] }
 env_logger = "0.9"
 log = "0.4"
 opendal = "0.17"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 tokio = { version = "1.20", features = ["fs", "macros", "rt-multi-thread"] }
 
 # Please comment the following patch while releasing.

--- a/oli/src/bin/oli.rs
+++ b/oli/src/bin/oli.rs
@@ -26,7 +26,8 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use anyhow::Result;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // Guard against infinite proxy recursion. This mostly happens due to
     // bugs in oli.
     do_recursion_guard()?;
@@ -39,7 +40,7 @@ fn main() -> Result<()> {
         .and_then(OsStr::to_str)
     {
         Some("oli") => {
-            oli::commands::cli::main()?;
+            oli::commands::cli::main().await?;
         }
         Some("ocp") => {
             oli::commands::cp::main()?;

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -22,7 +22,7 @@ pub fn main() -> Result<()> {
     match cli().get_matches().subcommand() {
         Some(("cp", args)) => {
             // 1. Parse profiles from env and build accessors
-            let _ = super::profile::build_accessors()?;
+            let _ = super::profile::build_operators()?;
             // 2. parse src and dst file path, and then choose the
             // right accessor to read and write.
             // TODO

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::str::FromStr;
 
 use anyhow::anyhow;
@@ -21,7 +20,7 @@ use clap::App;
 use clap::AppSettings;
 use opendal::Object;
 
-pub fn main() -> Result<()> {
+pub async fn main() -> Result<()> {
     match cli().get_matches().subcommand() {
         Some(("cp", args)) => {
             let source_path = args
@@ -36,14 +35,9 @@ pub fn main() -> Result<()> {
 
             let target_object = build_object(target_path)?;
 
-            tokio::runtime::Builder::new_multi_thread()
-                .build()?
-                .block_on(async move {
-                    // TODO: remove unwrap()
-                    let size = source_object.metadata().await.unwrap().content_length();
-                    let reader = source_object.reader().await.unwrap();
-                    target_object.write_from(size, reader).await.unwrap();
-                });
+            let size = source_object.metadata().await?.content_length();
+            let reader = source_object.reader().await?;
+            target_object.write_from(size, reader).await?;
         }
         _ => return Err(anyhow!("not handled")),
     }

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -61,3 +61,36 @@ fn build_object(path: &str) -> Result<Object> {
     let operator = super::profile::build_operator(&cp_path)?;
     Ok(operator.object(&cp_path.path()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_cmd::prelude::*;
+    
+    use std::env;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    #[tokio::test]
+    async fn test_basic_cp() -> Result<()> {
+        let dir = env::temp_dir();
+        fs::create_dir_all(dir.clone())?;
+        let src_path = Path::new(&dir).join("src.txt");
+        let dst_path = Path::new(&dir).join("dst.txt");
+        let expect = "hello";
+        fs::write(&src_path, expect)?;
+
+        let mut cmd = Command::cargo_bin("oli")?;
+
+        cmd.arg("cp")
+            .arg(src_path.as_os_str())
+            .arg(dst_path.as_os_str());
+        cmd.assert().success();
+
+        let actual = fs::read_to_string(&dst_path)?;
+        assert_eq!(expect, actual);
+        Ok(())
+    }
+}

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -33,13 +33,13 @@ pub fn main() -> Result<()> {
             // right operator to read and write.
             let source_path = args
                 .get_one::<String>("source_file")
-                .ok_or(anyhow!("missing source_file"))?;
+                .ok_or_else(|| anyhow!("missing source_file"))?;
 
             let source_object = build_object(source_path, &operators, &fs_operator)?;
 
             let target_path = args
                 .get_one::<String>("target_file")
-                .ok_or(anyhow!("missing target_file"))?;
+                .ok_or_else(|| anyhow!("missing target_file"))?;
 
             let target_object = build_object(target_path, &operators, &fs_operator)?;
 
@@ -84,7 +84,7 @@ fn build_object(
         CopyPath::Profile((name, path)) => {
             let operator = operators
                 .get(&name)
-                .ok_or(anyhow!("profile group not found"))?;
+                .ok_or_else(|| anyhow!("profile group not found"))?;
             Ok(operator.object(&path))
         }
     }

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -61,36 +61,3 @@ fn build_object(path: &str) -> Result<Object> {
     let operator = super::profile::build_operator(&cp_path)?;
     Ok(operator.object(&cp_path.path()))
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use assert_cmd::prelude::*;
-    
-    use std::env;
-    use std::fs;
-    use std::path::Path;
-    use std::process::Command;
-
-    #[tokio::test]
-    async fn test_basic_cp() -> Result<()> {
-        let dir = env::temp_dir();
-        fs::create_dir_all(dir.clone())?;
-        let src_path = Path::new(&dir).join("src.txt");
-        let dst_path = Path::new(&dir).join("dst.txt");
-        let expect = "hello";
-        fs::write(&src_path, expect)?;
-
-        let mut cmd = Command::cargo_bin("oli")?;
-
-        cmd.arg("cp")
-            .arg(src_path.as_os_str())
-            .arg(dst_path.as_os_str());
-        cmd.assert().success();
-
-        let actual = fs::read_to_string(&dst_path)?;
-        assert_eq!(expect, actual);
-        Ok(())
-    }
-}

--- a/oli/src/commands/cli.rs
+++ b/oli/src/commands/cli.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::path::PathBuf;
+
 use anyhow::anyhow;
 use anyhow::Result;
 use clap::App;
@@ -18,7 +20,18 @@ use clap::AppSettings;
 
 pub fn main() -> Result<()> {
     match cli().get_matches().subcommand() {
-        Some(("cp", _)) => println!("got oli cp"),
+        Some(("cp", args)) => {
+            // 1. Parse profiles from env and build accessors
+            let _ = super::profile::build_accessors()?;
+            // 2. parse src and dst file path, and then choose the
+            // right accessor to read and write.
+            // TODO
+            println!(
+                "got oli cp, src: {:?}, target: {:?}",
+                args.get_one::<PathBuf>("source_file"),
+                args.get_one::<PathBuf>("target_file")
+            )
+        }
         _ => return Err(anyhow!("not handled")),
     }
 

--- a/oli/src/commands/cp.rs
+++ b/oli/src/commands/cp.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use anyhow::Result;
+use clap::builder::PathBufValueParser;
 use clap::App;
 use clap::AppSettings;
+use clap::Arg;
 
 pub fn main() -> Result<()> {
     let _ = cli("ocp").get_matches();
@@ -26,7 +28,16 @@ pub(crate) fn cli(name: &str) -> App<'static> {
         .version("0.10.0")
         .about("copy")
         .setting(AppSettings::DeriveDisplayOrder)
-        .setting(AppSettings::SubcommandRequiredElseHelp);
+        .arg(
+            Arg::new("source_file")
+                .required(true)
+                .value_parser(PathBufValueParser::new()),
+        )
+        .arg(
+            Arg::new("target_file")
+                .required(true)
+                .value_parser(PathBufValueParser::new()),
+        );
 
     app
 }

--- a/oli/src/commands/cp.rs
+++ b/oli/src/commands/cp.rs
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use anyhow::Result;
-use clap::builder::PathBufValueParser;
+use clap::builder::NonEmptyStringValueParser;
 use clap::App;
 use clap::AppSettings;
 use clap::Arg;
@@ -31,12 +32,12 @@ pub(crate) fn cli(name: &str) -> App<'static> {
         .arg(
             Arg::new("source_file")
                 .required(true)
-                .value_parser(PathBufValueParser::new()),
+                .value_parser(NonEmptyStringValueParser::new()),
         )
         .arg(
             Arg::new("target_file")
                 .required(true)
-                .value_parser(PathBufValueParser::new()),
+                .value_parser(NonEmptyStringValueParser::new()),
         );
 
     app

--- a/oli/src/commands/mod.rs
+++ b/oli/src/commands/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 pub mod cli;
 pub mod cp;
+pub(crate) mod profile;

--- a/oli/src/commands/mod.rs
+++ b/oli/src/commands/mod.rs
@@ -11,6 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 pub mod cli;
 pub mod cp;
 pub(crate) mod profile;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_oli_cp() {}
+}

--- a/oli/src/commands/mod.rs
+++ b/oli/src/commands/mod.rs
@@ -15,11 +15,3 @@
 pub mod cli;
 pub mod cp;
 pub(crate) mod profile;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_oli_cp() {}
-}

--- a/oli/src/commands/profile.rs
+++ b/oli/src/commands/profile.rs
@@ -34,10 +34,6 @@ impl OliProfileGroup {
         let prefix = group_prefix(group);
         let profiles = env::vars()
             .filter_map(|(k, v)| k.strip_prefix(&prefix).map(|k| (k.to_lowercase(), v)))
-            // .filter_map(|(k, v)| match k.strip_prefix(&prefix) {
-            //     Some(k) => Some((k.to_lowercase(), v)),
-            //     None => None,
-            // })
             .collect::<HashMap<String, String>>();
 
         match profiles.get("type") {

--- a/oli/src/commands/profile.rs
+++ b/oli/src/commands/profile.rs
@@ -1,0 +1,154 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::env;
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use anyhow::Result;
+use opendal::Accessor;
+use opendal::services::azblob;
+
+const OLI_PROFILE_PREFIX: &str = "OLI_PROFILE_";
+
+pub struct OliProfileGroup {
+    pub name: String,
+    pub typ: String,
+    pub values: HashMap<String, String>,
+}
+
+pub struct OliAccessor {
+    pub name: String,
+    pub accessor: Box<dyn Accessor>,
+}
+
+impl OliAccessor {
+    pub fn new(name: String, accessor: Box<dyn Accessor>) -> Self {
+        Self {
+            name,
+            accessor,
+        }
+    }
+}
+
+impl OliProfileGroup {
+    pub fn parse(name: &str, kvs: HashMap<String, String>) -> Result<Self> {
+        if let Some(typ) = kvs.get("type") {
+            Ok(OliProfileGroup {
+                name: name.to_string(),
+                typ: typ.to_string(),
+                values: kvs,
+            })
+        } else {
+            Err(anyhow!("oli profile must contains type"))
+        }
+    }
+}
+
+pub(crate) fn build_accessors() -> Result<Vec<OliAccessor>> {
+    let profiles = get_oli_profiles_from_env();
+    let groups = parse_oli_profile_groups(profiles)?;
+
+    let mut ret = Vec::new();
+    for group in groups {
+        let accessor = build_accessor(&group)?;
+        let oli_accessor = OliAccessor::new(group.name.clone(), accessor);
+        ret.push(oli_accessor);
+    }
+    Ok(ret)
+}
+
+fn get_oli_profiles_from_env() -> Vec<(String, String)> {
+    env::vars()
+        .filter(|(k, _)| k.starts_with(OLI_PROFILE_PREFIX))
+        .collect::<Vec<(String, String)>>()
+}
+
+fn parse_oli_profile_groups(profiles: Vec<(String, String)>) -> Result<Vec<OliProfileGroup>> {
+    let mut groups: HashMap<String, HashMap<String, String>> = HashMap::new();
+    for (key, value) in profiles {
+        let (group, trimmed_key) = parse_oli_profile(key)?;
+        if !groups.contains_key(&group) {
+            groups.insert(group.clone(), HashMap::new());
+        }
+        groups
+            .get_mut(&group)
+            .unwrap()
+            .insert(trimmed_key.to_lowercase(), value);
+    }
+
+    let mut rets = Vec::new();
+    for (name, kvs) in groups {
+        let group = OliProfileGroup::parse(&name, kvs)?;
+        rets.push(group);
+    }
+
+    Ok(rets)
+}
+
+fn parse_oli_profile(key: String) -> Result<(String, String)> {
+    let name_value = key
+        .strip_prefix(OLI_PROFILE_PREFIX)
+        .ok_or_else(|| anyhow!("invalid oli profile prefix"))?
+        .split_once('_');
+
+    match name_value {
+        Some((name, value)) => Ok((name.to_string(), value.to_string())),
+        None => Err(anyhow!("split name and value error")),
+    }
+}
+
+fn build_accessor(group: &OliProfileGroup) -> Result<Box<dyn Accessor>> {
+    let json_str = serde_json::to_string(&group.values)?;
+    let scheme = opendal::Scheme::from_str(&group.typ)?;
+    match scheme {
+        opendal::Scheme::Azblob => {
+            let builder = serde_json::from_str::<azblob::Builder>(&json_str)?.build()?;
+            Ok(Box::new(builder))
+        }
+        _ => Err(anyhow!("invalid scheme"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_accessors() -> Result<()> {
+        assert_eq!("azblob", opendal::Scheme::Azblob.to_string());
+        env::set_var("OLI_PROFILE_SRC_TYPE", "azblob");
+        env::set_var("OLI_PROFILE_SRC_ENDPOINT", "endpoint_value");
+        env::set_var("OLI_PROFILE_SRC_CONTAINER", "container_value");
+        env::set_var("OLI_PROFILE_SRC_ROOT", "/");
+        env::set_var("OLI_PROFILE_DST_TYPE", "azblob");
+        env::set_var("OLI_PROFILE_DST_ENDPOINT", "endpoint_value");
+        env::set_var("OLI_PROFILE_DST_CONTAINER", "container_value");
+        env::set_var("OLI_PROFILE_DST_ROOT", "/");
+        let accessors = build_accessors()?;
+        assert_eq!(2, accessors.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_oli_profile_groups() -> Result<()> {
+        env::set_var("OLI_PROFILE_SRC_TYPE", "S3");
+        env::set_var("OLI_PROFILE_SRC_ENDPOINT", "http://127.0.0.1");
+        let envs = get_oli_profiles_from_env();
+        let groups = parse_oli_profile_groups(envs)?;
+        assert_eq!(1, groups.len());
+        Ok(())
+    }
+}

--- a/oli/tests/cp.rs
+++ b/oli/tests/cp.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+
+#[tokio::test]
+async fn test_basic_cp() -> Result<()> {
+    let dir = env::temp_dir();
+    fs::create_dir_all(dir.clone())?;
+    let src_path = Path::new(&dir).join("src.txt");
+    let dst_path = Path::new(&dir).join("dst.txt");
+    let expect = "hello";
+    fs::write(&src_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("cp")
+        .arg(src_path.as_os_str())
+        .arg(dst_path.as_os_str());
+    cmd.assert().success();
+
+    let actual = fs::read_to_string(&dst_path)?;
+    assert_eq!(expect, actual);
+    Ok(())
+}

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -30,6 +30,7 @@ use http::StatusCode;
 use log::debug;
 use log::info;
 use reqsign::services::azure::storage::Signer;
+use serde::Deserialize;
 
 use super::dir_stream::DirStream;
 use super::error::parse_error;
@@ -69,7 +70,7 @@ use crate::Scheme;
 const X_MS_BLOB_TYPE: &str = "x-ms-blob-type";
 
 /// Builder for azblob services
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Deserialize)]
 pub struct Builder {
     root: Option<String>,
     container: String,

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -30,7 +30,6 @@ use http::StatusCode;
 use log::debug;
 use log::info;
 use reqsign::services::azure::storage::Signer;
-use serde::Deserialize;
 
 use super::dir_stream::DirStream;
 use super::error::parse_error;
@@ -71,7 +70,7 @@ use crate::Scheme;
 const X_MS_BLOB_TYPE: &str = "x-ms-blob-type";
 
 /// Builder for azblob services
-#[derive(Default, Clone, Deserialize)]
+#[derive(Default, Clone)]
 pub struct Builder {
     root: Option<String>,
     container: String,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Related to #675

Implement basic `cp` for oli:

```
oli cp <source_file> <target_file>
```

- [x] Parse oli profiles from env, and then build accessor objects.
- [x] Parse source and target file path, and then find the right accessor.
- [x] Read from source and then write to target.
- [ ] Add docs.
