### PR TITLE
chore: also parse 'FTPS' to Scheme::Ftp

### DIFF
--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -114,7 +114,7 @@ impl FromStr for Scheme {
             "hdfs" => Ok(Scheme::Hdfs),
             "http" | "https" => Ok(Scheme::Http),
             #[cfg(feature = "services-ftp")]
-            "ftps" | "ftp" => Ok(Scheme::Ftp),
+            "ftp" | "ftps" => Ok(Scheme::Ftp),
             #[cfg(feature = "services-ipfs")]
             "ipfs" | "ipns" => Ok(Scheme::Ipfs),
             "ipmfs" => Ok(Scheme::Ipmfs),

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -114,7 +114,7 @@ impl FromStr for Scheme {
             "hdfs" => Ok(Scheme::Hdfs),
             "http" | "https" => Ok(Scheme::Http),
             #[cfg(feature = "services-ftp")]
-            "ftp" => Ok(Scheme::Ftp),
+            "ftps" | "ftp" => Ok(Scheme::Ftp),
             #[cfg(feature = "services-ipfs")]
             "ipfs" | "ipns" => Ok(Scheme::Ipfs),
             "ipmfs" => Ok(Scheme::Ipmfs),


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

`FTPS` is a TLS extension to FTP and `OpenDAL` supports it. But the `Scheme` can only be parsed from "FTP"
