### PR TITLE
chore: fix error message

### DIFF
--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -504,7 +504,7 @@ impl Backend {
     async fn ftp_connect(&self, op: Operation) -> Result<FtpStream> {
         let stream = FtpStream::connect(&self.endpoint)
             .await
-            .map_err(|e| new_request_connection_err(e, Operation::Delete, &self.endpoint))?;
+            .map_err(|e| new_request_connection_err(e, op, &self.endpoint))?;
 
         // switch to secure mode if ssl/tls is on.
         let mut ftp_stream = if self.enable_secure {


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

When FTP connect failed, the failed operation in message will always be `Delete`
