### PR TITLE
fix: update metrics on result

### DIFF
--- a/src/layers/metrics.rs
+++ b/src/layers/metrics.rs
@@ -119,6 +119,29 @@ impl Debug for MetricsAccessor {
     }
 }
 
+impl MetricsAccessor {
+    // update metrics on result types
+    #[inline]
+    fn res_metric<T>(&self, result: Result<T>, op: Operation) -> Result<T> {
+        if let Err(e) = &result {
+            if e.kind() == ErrorKind::Other {
+                increment_counter!(
+                METRIC_FAILURES_TOTAL,
+                LABEL_SERVICE => self.meta.scheme().into_static(),
+                LABEL_OPERATION => op.into_static(),
+                )
+            } else {
+                increment_counter!(
+                METRIC_ERRORS_TOTAL,
+                LABEL_SERVICE => self.meta.scheme().into_static(),
+                LABEL_OPERATION => op.into_static(),
+                )
+            }
+        }
+        result
+    }
+}
+
 #[async_trait]
 impl Accessor for MetricsAccessor {
     fn metadata(&self) -> AccessorMetadata {
@@ -158,7 +181,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Create.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Create)
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<BytesReader> {
@@ -184,7 +207,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Read.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Read)
     }
 
     async fn write(&self, path: &str, args: OpWrite, r: BytesReader) -> Result<u64> {
@@ -206,7 +229,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Write.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Write)
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<ObjectMetadata> {
@@ -226,7 +249,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Stat.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Stat)
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<()> {
@@ -246,7 +269,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Delete.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Delete)
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<DirStreamer> {
@@ -266,7 +289,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::List.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::List)
     }
 
     fn presign(&self, path: &str, args: OpPresign) -> Result<PresignedRequest> {
@@ -286,7 +309,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::Presign.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::Presign)
     }
 
     async fn create_multipart(&self, path: &str, args: OpCreateMultipart) -> Result<String> {
@@ -306,7 +329,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::CreateMultipart.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::CreateMultipart)
     }
 
     async fn write_multipart(
@@ -333,7 +356,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::WriteMultipart.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::WriteMultipart)
     }
 
     async fn complete_multipart(&self, path: &str, args: OpCompleteMultipart) -> Result<()> {
@@ -353,7 +376,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::CompleteMultipart.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::CompleteMultipart)
     }
 
     async fn abort_multipart(&self, path: &str, args: OpAbortMultipart) -> Result<()> {
@@ -373,7 +396,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::AbortMultipart.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::AbortMultipart)
     }
 
     fn blocking_create(&self, path: &str, args: OpCreate) -> Result<()> {
@@ -393,7 +416,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingCreate.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingCreate)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<BlockingBytesReader> {
@@ -419,7 +442,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingRead.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingRead)
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite, r: BlockingBytesReader) -> Result<u64> {
@@ -445,7 +468,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingWrite.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingWrite)
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<ObjectMetadata> {
@@ -465,7 +488,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingStat.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingStat)
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<()> {
@@ -485,7 +508,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingDelete.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingDelete)
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<DirIterator> {
@@ -505,7 +528,7 @@ impl Accessor for MetricsAccessor {
             LABEL_OPERATION => Operation::BlockingList.into_static(),
         );
 
-        result
+        self.res_metric(result, Operation::BlockingList)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR updates `failure` and `error` metics in Operators.

fixes: #706
