### PR TITLE
refactor: replace error::other with new_other_object_error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -88,15 +88,6 @@ impl ObjectError {
     }
 }
 
-/// Copied for [`io::Error::other`], should be removed after `io_error_other` stable.
-#[deprecated(since = "0.18.0", note = "please use `new_other_object_error` instead")]
-pub fn other<E>(error: E) -> io::Error
-where
-    E: Into<Box<dyn std::error::Error + Send + Sync>>,
-{
-    io::Error::new(io::ErrorKind::Other, error.into())
-}
-
 /// Creates new Unsupported Object Error.
 pub fn new_unsupported_object_error(op: Operation, path: &str) -> io::Error {
     io::Error::new(

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,7 +89,7 @@ impl ObjectError {
 }
 
 /// Copied for [`io::Error::other`], should be removed after `io_error_other` stable.
-#[deprecated(since="0.18.0", note="please use `new_other_object_error` instead")]
+#[deprecated(since = "0.18.0", note = "please use `new_other_object_error` instead")]
 pub fn other<E>(error: E) -> io::Error
 where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -110,7 +110,11 @@ pub fn new_unsupported_object_error(op: Operation, path: &str) -> io::Error {
 }
 
 /// Creates an error as [`ObjectError`] and wrapped with [`io::Error::other`]
-pub fn new_other_object_error(op: Operation, path: &str, source: impl Into<anyhow::Error>) -> io::Error {
+pub fn new_other_object_error(
+    op: Operation,
+    path: &str,
+    source: impl Into<anyhow::Error>,
+) -> io::Error {
     io::Error::new(io::ErrorKind::Other, ObjectError::new(op, path, source))
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,10 +89,7 @@ impl ObjectError {
 }
 
 /// Copied for [`io::Error::other`], should be removed after `io_error_other` stable.
-///
-/// TODO:
-///
-/// - Refactor this into `new_other_object_error` and `new_other_backend_error`
+#[deprecated(since="0.18.0", note="please use `new_other_object_error` instead")]
 pub fn other<E>(error: E) -> io::Error
 where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -110,4 +107,17 @@ pub fn new_unsupported_object_error(op: Operation, path: &str) -> io::Error {
             anyhow::anyhow!("operation is not supported by underlying services"),
         ),
     )
+}
+
+/// Creates an error as [`ObjectError`] and wrapped with [`io::Error::other`]
+pub fn new_other_object_error(op: Operation, path: &str, source: impl Into<anyhow::Error>) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, ObjectError::new(op, path, source))
+}
+
+/// Creates an error as [`BackendError`] and wrapped with [`io::Error::other`]
+pub fn new_other_backend_error(
+    context: HashMap<String, String>,
+    source: impl Into<anyhow::Error>,
+) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, BackendError::new(context, source))
 }

--- a/src/http_util/error.rs
+++ b/src/http_util/error.rs
@@ -24,27 +24,19 @@ use http::HeaderValue;
 use http::Response;
 use http::StatusCode;
 
-use crate::error::other;
+use crate::error::new_other_object_error;
 use crate::error::ObjectError;
 use crate::http_util::IncomingAsyncBody;
 use crate::ops::Operation;
 
 /// Create error happened during building http request.
 pub fn new_request_build_error(op: Operation, path: &str, err: http::Error) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("building request: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("building request: {err:?}"))
 }
 
 /// Create error happened during signing http request.
 pub fn new_request_sign_error(op: Operation, path: &str, err: anyhow::Error) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("signing request: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("signing request: {err:?}"))
 }
 
 /// Create error happened during sending http request.

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -397,7 +397,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    
     use std::io;
     use std::sync::Arc;
     use std::time::Duration;
@@ -407,7 +407,7 @@ mod tests {
     use backon::ConstantBackoff;
     use tokio::sync::Mutex;
 
-    use crate::error::new_other_backend_error;
+    
     use crate::layers::RetryLayer;
     use crate::ops::OpRead;
     use crate::Accessor;
@@ -430,8 +430,8 @@ mod tests {
                     io::ErrorKind::Interrupted,
                     anyhow!("retryable_error"),
                 )),
-                _ => Err(new_other_backend_error(
-                    HashMap::new(),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::Other,
                     anyhow!("not_retryable_error"),
                 )),
             }
@@ -467,7 +467,10 @@ mod tests {
 
         let result = op.object("not_retryable_error").read().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not_retryable_error"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not_retryable_error"));
         // The error is not retryable, we should only request it once.
         assert_eq!(*srv.attempt.lock().await, 1);
 

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -397,6 +397,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::io;
     use std::sync::Arc;
     use std::time::Duration;
@@ -406,7 +407,7 @@ mod tests {
     use backon::ConstantBackoff;
     use tokio::sync::Mutex;
 
-    use crate::error::other;
+    use crate::error::new_other_backend_error;
     use crate::layers::RetryLayer;
     use crate::ops::OpRead;
     use crate::Accessor;
@@ -429,7 +430,7 @@ mod tests {
                     io::ErrorKind::Interrupted,
                     anyhow!("retryable_error"),
                 )),
-                _ => Err(other(anyhow!("not_retryable_error"))),
+                _ => Err(new_other_backend_error(HashMap::new(), anyhow!("not_retryable_error"))),
             }
         }
     }

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -430,7 +430,10 @@ mod tests {
                     io::ErrorKind::Interrupted,
                     anyhow!("retryable_error"),
                 )),
-                _ => Err(new_other_backend_error(HashMap::new(), anyhow!("not_retryable_error"))),
+                _ => Err(new_other_backend_error(
+                    HashMap::new(),
+                    anyhow!("not_retryable_error"),
+                )),
             }
         }
     }

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -467,7 +467,7 @@ mod tests {
 
         let result = op.object("not_retryable_error").read().await;
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "not_retryable_error");
+        assert!(result.unwrap_err().to_string().contains("not_retryable_error"));
         // The error is not retryable, we should only request it once.
         assert_eq!(*srv.attempt.lock().await, 1);
 

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -397,7 +397,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    
+
     use std::io;
     use std::sync::Arc;
     use std::time::Duration;
@@ -407,7 +407,6 @@ mod tests {
     use backon::ConstantBackoff;
     use tokio::sync::Mutex;
 
-    
     use crate::layers::RetryLayer;
     use crate::ops::OpRead;
     use crate::Accessor;

--- a/src/object.rs
+++ b/src/object.rs
@@ -30,8 +30,8 @@ use serde::Serialize;
 use time::Duration;
 use time::OffsetDateTime;
 
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::io::BytesRead;
 use crate::io_util::seekable_read;
 #[cfg(feature = "compress")]
@@ -353,11 +353,11 @@ impl Object {
     /// ```
     pub async fn range_read(&self, range: impl RangeBounds<u64>) -> Result<Vec<u8>> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Read,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let s = self
@@ -404,11 +404,11 @@ impl Object {
     /// ```
     pub fn blocking_range_read(&self, range: impl RangeBounds<u64>) -> Result<Vec<u8>> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Read,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let mut s = self.acc.blocking_read(
@@ -494,11 +494,11 @@ impl Object {
     /// ```
     pub async fn range_reader(&self, range: impl RangeBounds<u64>) -> Result<impl BytesRead> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Read,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         self.acc.read(self.path(), OpRead::new(range)).await
@@ -527,11 +527,11 @@ impl Object {
         range: impl RangeBounds<u64>,
     ) -> Result<impl BlockingBytesRead> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Read,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         self.acc.blocking_read(self.path(), OpRead::new(range))
@@ -734,11 +734,11 @@ impl Object {
     /// ```
     pub async fn write(&self, bs: impl Into<Vec<u8>>) -> Result<()> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Write,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let bs = bs.into();
@@ -774,11 +774,11 @@ impl Object {
     /// ```
     pub fn blocking_write(&self, bs: impl Into<Vec<u8>>) -> Result<()> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Write,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let bs = bs.into();
@@ -817,11 +817,11 @@ impl Object {
     /// ```
     pub async fn write_from(&self, size: u64, br: impl BytesRead + 'static) -> Result<()> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Write,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let _ = self
@@ -864,11 +864,11 @@ impl Object {
         br: impl BlockingBytesRead + 'static,
     ) -> Result<()> {
         if !validate_path(self.path(), ObjectMode::FILE) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Write,
                 self.path(),
                 anyhow!("Is a directory"),
-            )));
+            ));
         }
 
         let _ = self
@@ -964,11 +964,11 @@ impl Object {
     /// ```
     pub async fn list(&self) -> Result<DirStreamer> {
         if !validate_path(self.path(), ObjectMode::DIR) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::List,
                 self.path(),
                 anyhow!("Not a directory"),
-            )));
+            ));
         }
 
         self.acc.list(self.path(), OpList::new()).await
@@ -1011,11 +1011,11 @@ impl Object {
     /// ```
     pub fn blocking_list(&self) -> Result<DirIterator> {
         if !validate_path(self.path(), ObjectMode::DIR) {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::List,
                 self.path(),
                 anyhow!("Not a directory"),
-            )));
+            ));
         }
 
         self.acc.blocking_list(self.path(), OpList::new())

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -23,8 +23,8 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use log::debug;
 
-use crate::error::other;
-use crate::error::BackendError;
+use crate::error::new_other_backend_error;
+
 use crate::io_util::BottomUpWalker;
 use crate::io_util::TopDownWalker;
 use crate::services;
@@ -142,10 +142,10 @@ impl Operator {
             Scheme::S3 => services::s3::Backend::from_iter(it)?.into(),
             Scheme::Obs => services::obs::Backend::from_iter(it)?.into(),
             Scheme::Custom(v) => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::default(),
                     anyhow!("custom service {v} is not supported"),
-                )))
+                ))
             }
         };
 

--- a/src/services/azblob/dir_stream.rs
+++ b/src/services/azblob/dir_stream.rs
@@ -30,8 +30,8 @@ use time::OffsetDateTime;
 
 use super::error::parse_error;
 use super::Backend;
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
@@ -93,7 +93,7 @@ impl futures::Stream for DirStream {
                         .into_body()
                         .bytes()
                         .await
-                        .map_err(|e| other(ObjectError::new(Operation::List, &path, e)))?;
+                        .map_err(|e| new_other_object_error(Operation::List, &path, e))?;
 
                     Ok(bs)
                 };
@@ -104,11 +104,11 @@ impl futures::Stream for DirStream {
                 let bs = ready!(Pin::new(fut).poll(cx))?;
 
                 let output: Output = de::from_reader(bs.reader()).map_err(|e| {
-                    other(ObjectError::new(
+                    new_other_object_error(
                         Operation::List,
                         &self.path,
                         anyhow!("deserialize xml: {e:?}"),
-                    ))
+                    )
                 })?;
 
                 // Try our best to check whether this list is done.
@@ -159,11 +159,11 @@ impl futures::Stream for DirStream {
                     let dt =
                         OffsetDateTime::parse(object.properties.last_modified.as_str(), &Rfc2822)
                             .map_err(|e| {
-                            other(ObjectError::new(
+                            new_other_object_error(
                                 Operation::List,
                                 &self.path,
                                 anyhow!("parse last modified RFC2822 datetime: {e:?}"),
-                            ))
+                            )
                         })?;
                     de.set_last_modified(dt);
 

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+
 use std::io::ErrorKind;
 use std::io::Read;
 use std::io::Result;
@@ -35,7 +35,7 @@ use crate::accessor::AccessorCapability;
 use crate::accessor::AccessorMetadata;
 use crate::dir::EmptyDirIterator;
 use crate::dir::EmptyDirStreamer;
-use crate::error::new_other_backend_error;
+
 use crate::error::new_other_object_error;
 
 use crate::ops::OpCreate;
@@ -87,8 +87,8 @@ impl Builder {
         if let Err(e) = std::fs::metadata(&root) {
             if e.kind() == ErrorKind::NotFound {
                 std::fs::create_dir_all(&root).map_err(|e| {
-                    new_other_backend_error(
-                        HashMap::new(),
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
                         anyhow!("create dir in {} error {:?}", &root, e),
                     )
                 })?;

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::io::ErrorKind;
 use std::io::Read;
 use std::io::Result;

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -43,9 +43,8 @@ use super::err::new_request_connection_err;
 use super::err::new_request_quit_err;
 use super::util::FtpReader;
 use crate::accessor::AccessorCapability;
-use crate::error::other;
-use crate::error::BackendError;
-use crate::error::ObjectError;
+use crate::error::new_other_backend_error;
+use crate::error::new_other_object_error;
 use crate::ops::OpCreate;
 use crate::ops::OpDelete;
 use crate::ops::OpList;
@@ -129,20 +128,20 @@ impl Builder {
         info!("ftp backend build started: {:?}", &self);
         let endpoint = match &self.endpoint {
             None => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::new(),
                     anyhow!("endpoint must be specified"),
-                )))
+                ))
             }
             Some(v) => v,
         };
 
         let endpoint_uri = match endpoint.parse::<Uri>() {
             Err(e) => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::new(),
                     anyhow!("endpoint must be valid uri: {:?}", e),
-                )));
+                ));
             }
             Ok(uri) => uri,
         };
@@ -159,10 +158,10 @@ impl Builder {
             Some("ftps") | None => true,
 
             Some(s) => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::new(),
                     anyhow!("endpoint scheme unsupported or invalid: {:?}", s),
-                )));
+                ));
             }
         };
 
@@ -173,10 +172,10 @@ impl Builder {
                 debug_assert!(!v.is_empty());
                 let mut v = v.clone();
                 if !v.starts_with('/') {
-                    return Err(other(BackendError::new(
+                    return Err(new_other_backend_error(
                         HashMap::from([("root".to_string(), v.clone())]),
                         anyhow!("root must start with /"),
-                    )));
+                    ));
                 }
                 if !v.ends_with('/') {
                     v.push('/');
@@ -276,11 +275,11 @@ impl Accessor for Backend {
                     }))
                     | Ok(()) => (),
                     Err(e) => {
-                        return Err(other(ObjectError::new(
+                        return Err(new_other_object_error(
                             Operation::Create,
                             path,
                             anyhow!("mkdir request: {e:?}"),
-                        )));
+                        ));
                     }
                 }
             } else {
@@ -331,11 +330,11 @@ impl Accessor for Backend {
                 return Err(Error::new(ErrorKind::NotFound, e));
             }
             Err(e) => {
-                return Err(other(ObjectError::new(
+                return Err(new_other_object_error(
                     Operation::Read,
                     path,
                     anyhow!("retr request: {e:?}"),
-                )));
+                ));
             }
             Ok(_) => (),
         }
@@ -469,11 +468,11 @@ impl Accessor for Backend {
             }))
             | Ok(_) => (),
             Err(e) => {
-                return Err(other(ObjectError::new(
+                return Err(new_other_object_error(
                     Operation::Delete,
                     path,
                     anyhow!("remove request: {e:?}"),
-                )));
+                ));
             }
         }
 
@@ -555,20 +554,20 @@ impl Backend {
                     })?;
                 } else {
                     // Other errors, return
-                    return Err(other(ObjectError::new(
+                    return Err(new_other_object_error(
                         op,
                         &self.endpoint,
                         anyhow!("cwd request: {e:?}"),
-                    )));
+                    ));
                 }
             }
             // Other errors, return.
             Err(e) => {
-                return Err(other(ObjectError::new(
+                return Err(new_other_object_error(
                     op,
                     &self.endpoint,
                     anyhow!("cwd request: {e:?}"),
-                )))
+                ))
             }
             // Do nothing if success.
             Ok(_) => (),

--- a/src/services/ftp/err.rs
+++ b/src/services/ftp/err.rs
@@ -27,15 +27,11 @@ use crate::ops::Operation;
 ///
 /// In the future, we may have our own error struct.
 pub fn new_request_connection_err(e: FtpError, op: Operation, path: &str) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("connection request: {e:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("connection request: {e:?}"))
 }
 
 pub fn new_request_quit_err(e: FtpError, op: Operation, path: &str) -> Error {
-    other(ObjectError::new(op, path, anyhow!("quit request: {e:?}")))
+    new_other_object_error(op, path, anyhow!("quit request: {e:?}"))
 }
 
 pub fn parse_io_error(err: Error, op: Operation, path: &str) -> Error {

--- a/src/services/ftp/err.rs
+++ b/src/services/ftp/err.rs
@@ -17,8 +17,7 @@ use std::io::Error;
 use anyhow::anyhow;
 use suppaftp::FtpError;
 
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::{ObjectError, new_other_object_error};
 use crate::ops::Operation;
 
 /// Parse error response into io::Error.

--- a/src/services/ftp/err.rs
+++ b/src/services/ftp/err.rs
@@ -17,7 +17,7 @@ use std::io::Error;
 use anyhow::anyhow;
 use suppaftp::FtpError;
 
-use crate::error::{ObjectError, new_other_object_error};
+use crate::error::{new_other_object_error, ObjectError};
 use crate::ops::Operation;
 
 /// Parse error response into io::Error.

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -26,8 +26,7 @@ use futures::FutureExt;
 use suppaftp::FtpStream;
 use suppaftp::Status;
 
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
 use crate::ops::Operation;
 use crate::BytesReader;
 

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -79,19 +79,19 @@ impl AsyncRead for FtpReader {
                                 ])
                                 .await
                                 .map_err(|e| {
-                                    other(ObjectError::new(
+                                    new_other_object_error(
                                         Operation::Read,
                                         path.as_str(),
                                         anyhow!("unexpected response: {e:?}"),
-                                    ))
+                                    )
                                 })?;
 
                                 ft.quit().await.map_err(|e| {
-                                    other(ObjectError::new(
+                                    new_other_object_error(
                                         Operation::Read,
                                         path.as_str(),
                                         anyhow!("quit request: {e:?}"),
-                                    ))
+                                    )
                                 })?;
 
                                 Ok(())

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -32,9 +32,8 @@ use super::dir_stream::DirStream;
 use super::error::parse_io_error;
 use crate::accessor::AccessorCapability;
 use crate::dir::EmptyDirStreamer;
-use crate::error::other;
-use crate::error::BackendError;
-use crate::error::ObjectError;
+use crate::error::new_other_backend_error;
+use crate::error::new_other_object_error;
 use crate::ops::OpCreate;
 use crate::ops::OpDelete;
 use crate::ops::OpList;
@@ -94,10 +93,10 @@ impl Builder {
 
         let name_node = match &self.name_node {
             None => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::new(),
                     anyhow!("endpoint must be specified"),
-                )))
+                ))
             }
             Some(v) => v,
         };
@@ -106,13 +105,13 @@ impl Builder {
         info!("backend use root {}", root);
 
         let client = hdrs::Client::connect(name_node).map_err(|e| {
-            other(BackendError::new(
+            new_other_backend_error(
                 HashMap::from([
                     ("root".to_string(), root.clone()),
                     ("endpoint".to_string(), name_node.clone()),
                 ]),
                 anyhow!("connect hdfs name node: {}", e),
-            ))
+            )
         })?;
 
         // Create root dir if not exist.
@@ -121,13 +120,13 @@ impl Builder {
                 debug!("root {} is not exist, creating now", root);
 
                 client.create_dir(&root).map_err(|e| {
-                    other(BackendError::new(
+                    new_other_backend_error(
                         HashMap::from([
                             ("root".to_string(), root.clone()),
                             ("endpoint".to_string(), name_node.clone()),
                         ]),
                         anyhow!("create root dir: {}", e),
-                    ))
+                    )
                 })?
             }
         }

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -189,11 +189,11 @@ impl Accessor for Backend {
                 let parent = PathBuf::from(&p)
                     .parent()
                     .ok_or_else(|| {
-                        other(ObjectError::new(
+                        new_other_object_error(
                             Operation::Create,
                             path,
                             anyhow!("malformed path: {:?}", path),
-                        ))
+                        )
                     })?
                     .to_path_buf();
 
@@ -246,11 +246,11 @@ impl Accessor for Backend {
         let parent = PathBuf::from(&p)
             .parent()
             .ok_or_else(|| {
-                other(ObjectError::new(
+                new_other_object_error(
                     Operation::Write,
                     path,
                     anyhow!("malformed path: {:?}", path),
-                ))
+                )
             })?
             .to_path_buf();
 

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -26,9 +26,9 @@ use log::info;
 
 use super::error::parse_error;
 use crate::accessor::AccessorCapability;
-use crate::error::other;
-use crate::error::BackendError;
-use crate::error::ObjectError;
+use crate::error::new_other_backend_error;
+use crate::error::new_other_object_error;
+
 use crate::http_util::new_request_build_error;
 use crate::http_util::new_request_send_error;
 use crate::http_util::parse_content_length;
@@ -101,10 +101,10 @@ impl Builder {
 
         let endpoint = match &self.endpoint {
             None => {
-                return Err(other(BackendError::new(
+                return Err(new_other_backend_error(
                     HashMap::new(),
                     anyhow!("endpoint must be specified"),
-                )))
+                ))
             }
             Some(v) => v,
         };
@@ -202,25 +202,25 @@ impl Accessor for Backend {
                 let mut m = ObjectMetadata::default();
 
                 if let Some(v) = parse_content_length(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_content_length(v);
                 }
 
                 if let Some(v) = parse_content_md5(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_content_md5(v);
                 }
 
                 if let Some(v) = parse_etag(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_etag(v);
                 }
 
                 if let Some(v) = parse_last_modified(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_last_modified(v);
                 }

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -40,9 +40,8 @@ use prost::Message;
 use super::error::parse_error;
 use super::ipld::PBNode;
 use crate::accessor::AccessorCapability;
-use crate::error::other;
-use crate::error::BackendError;
-use crate::error::ObjectError;
+use crate::error::new_other_backend_error;
+use crate::error::new_other_object_error;
 use crate::http_util::new_request_build_error;
 use crate::http_util::new_request_send_error;
 use crate::http_util::parse_content_length;
@@ -117,19 +116,19 @@ impl Builder {
 
         let root = normalize_root(&self.root.take().unwrap_or_default());
         if !root.starts_with("/ipfs/") && !root.starts_with("/ipns/") {
-            return Err(other(BackendError::new(
+            return Err(new_other_backend_error(
                 HashMap::from([("root".to_string(), root)]),
                 anyhow!("root must start with /ipfs/ or /ipns/"),
-            )));
+            ));
         }
         info!("backend use root {}", root);
 
         let endpoint = match &self.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
-            None => Err(other(BackendError::new(
+            None => Err(new_other_backend_error(
                 HashMap::from([("endpoint".to_string(), "".to_string())]),
                 anyhow!("endpoint is empty"),
-            ))),
+            )),
         }?;
         info!("backend use endpoint {}", &endpoint);
 

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -323,13 +323,13 @@ impl Accessor for Backend {
                 let mut m = ObjectMetadata::default();
 
                 if let Some(v) = parse_content_length(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_content_length(v);
                 }
 
                 if let Some(v) = parse_etag(resp.headers())
-                    .map_err(|e| other(ObjectError::new(Operation::Stat, path, e)))?
+                    .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
                 {
                     m.set_etag(v);
 
@@ -481,7 +481,7 @@ impl Stream for DirStream {
                         .into_body()
                         .bytes()
                         .await
-                        .map_err(|e| other(ObjectError::new(Operation::List, &path, e)))?;
+                        .map_err(|e| new_other_object_error(Operation::List, &path, e))?;
 
                     Ok(bs)
                 };
@@ -493,11 +493,11 @@ impl Stream for DirStream {
                 let bs = ready!(Pin::new(fut).poll(cx))?;
 
                 let pb_node = PBNode::decode(bs).map_err(|e| {
-                    other(ObjectError::new(
+                    new_other_object_error(
                         Operation::List,
                         &self.path,
                         anyhow!("deserialize protobuf: {e:?}"),
-                    ))
+                    )
                 })?;
 
                 let names = pb_node

--- a/src/services/ipmfs/backend.rs
+++ b/src/services/ipmfs/backend.rs
@@ -29,8 +29,8 @@ use super::builder::Builder;
 use super::dir_stream::DirStream;
 use super::error::parse_error;
 use crate::accessor::AccessorCapability;
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::http_util::new_request_build_error;
 use crate::http_util::new_request_send_error;
 use crate::http_util::new_response_consume_error;
@@ -195,11 +195,11 @@ impl Accessor for Backend {
                     .map_err(|err| new_response_consume_error(Operation::Stat, path, err))?;
 
                 let res: IpfsStatResponse = serde_json::from_slice(&bs).map_err(|err| {
-                    other(ObjectError::new(
+                    new_other_object_error(
                         Operation::Stat,
                         path,
                         anyhow!("deserialize json: {err:?}"),
-                    ))
+                    )
                 })?;
 
                 let mut meta = ObjectMetadata::default();

--- a/src/services/ipmfs/dir_stream.rs
+++ b/src/services/ipmfs/dir_stream.rs
@@ -28,8 +28,8 @@ use serde::Deserialize;
 
 use super::error::parse_error;
 use super::Backend;
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
@@ -80,11 +80,11 @@ impl futures::Stream for DirStream {
                     }
 
                     let bs = resp.into_body().bytes().await.map_err(|e| {
-                        other(ObjectError::new(
+                        new_other_object_error(
                             Operation::List,
                             &path,
                             anyhow!("read body: {:?}", e),
-                        ))
+                        )
                     })?;
 
                     Ok(bs)
@@ -97,14 +97,14 @@ impl futures::Stream for DirStream {
 
                 let entries_body: IpfsLsResponse =
                     serde_json::from_slice(&contents).map_err(|err| {
-                        other(ObjectError::new(
+                        new_other_object_error(
                             Operation::List,
                             &path,
                             anyhow!(
                                 "deserialize {} list response: {err:?}",
                                 String::from_utf8_lossy(&contents)
                             ),
-                        ))
+                        )
                     })?;
 
                 self.state = State::Listing((entries_body.entries.unwrap_or_default(), 0));

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -32,7 +32,8 @@ use futures::AsyncWrite;
 use parking_lot::Mutex;
 
 use crate::accessor::AccessorCapability;
-use crate::error::other;
+use crate::error::new_other_object_error;
+
 use crate::error::ObjectError;
 use crate::ops::OpCreate;
 use crate::ops::OpDelete;
@@ -114,22 +115,22 @@ impl Accessor for Backend {
         let mut data = data.clone();
         if let Some(offset) = args.offset() {
             if offset >= data.len() as u64 {
-                return Err(other(ObjectError::new(
+                return Err(new_other_object_error(
                     Operation::Read,
                     path,
                     anyhow!("offset out of bound {} >= {}", offset, data.len()),
-                )));
+                ));
             }
             data = data.slice(offset as usize..data.len());
         };
 
         if let Some(size) = args.size() {
             if size > data.len() as u64 {
-                return Err(other(ObjectError::new(
+                return Err(new_other_object_error(
                     Operation::Read,
                     path,
                     anyhow!("size out of bound {} > {}", size, data.len()),
-                )));
+                ));
             }
             data = data.slice(0..size as usize);
         };
@@ -141,11 +142,11 @@ impl Accessor for Backend {
         let mut buf = Vec::with_capacity(args.size() as usize);
         let n = futures::io::copy(r, &mut buf).await?;
         if n != args.size() {
-            return Err(other(ObjectError::new(
+            return Err(new_other_object_error(
                 Operation::Write,
                 path,
                 anyhow!("write short, expect {} actual {}", args.size(), n),
-            )));
+            ));
         }
         let mut map = self.inner.lock();
         map.insert(path.to_string(), Bytes::from(buf));
@@ -260,7 +261,7 @@ impl AsyncWrite for MapWriter {
 
     fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
         if self.buf.len() != self.size as usize {
-            return Poll::Ready(Err(other(ObjectError::new(
+            return Poll::Ready(Err(new_other_object_error(
                 Operation::Write,
                 &self.path,
                 anyhow!(
@@ -268,7 +269,7 @@ impl AsyncWrite for MapWriter {
                     self.size,
                     self.buf.len()
                 ),
-            ))));
+            )));
         }
 
         let buf = mem::take(&mut self.buf);

--- a/src/services/obs/dir_stream.rs
+++ b/src/services/obs/dir_stream.rs
@@ -26,8 +26,8 @@ use futures::Future;
 use quick_xml::de;
 use serde::Deserialize;
 
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
@@ -89,7 +89,7 @@ impl futures::Stream for DirStream {
                         .into_body()
                         .bytes()
                         .await
-                        .map_err(|e| other(ObjectError::new(Operation::List, &path, e)))?;
+                        .map_err(|e| new_other_object_error(Operation::List, &path, e))?;
 
                     Ok(bs)
                 };
@@ -99,7 +99,7 @@ impl futures::Stream for DirStream {
             State::Sending(fut) => {
                 let bs = ready!(Pin::new(fut).poll(cx))?;
                 let output: Output = de::from_reader(bs.reader())
-                    .map_err(|e| other(ObjectError::new(Operation::List, &self.path, e)))?;
+                    .map_err(|e| new_other_object_error(Operation::List, &self.path, e))?;
 
                 // Try our best to check whether this list is done.
                 //

--- a/src/services/redis/error.rs
+++ b/src/services/redis/error.rs
@@ -17,8 +17,7 @@ use std::io::Error;
 use anyhow::anyhow;
 use redis::RedisError;
 
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
 use crate::ops::Operation;
 
 pub(crate) fn new_async_connection_error(err: RedisError, op: Operation, path: &str) -> Error {

--- a/src/services/redis/error.rs
+++ b/src/services/redis/error.rs
@@ -22,11 +22,7 @@ use crate::error::ObjectError;
 use crate::ops::Operation;
 
 pub(crate) fn new_async_connection_error(err: RedisError, op: Operation, path: &str) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("getting async connection: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("getting async connection: {err:?}"))
 }
 
 pub(crate) fn new_serialize_metadata_error(
@@ -34,11 +30,7 @@ pub(crate) fn new_serialize_metadata_error(
     op: Operation,
     path: &str,
 ) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("serialize metadata: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("serialize metadata: {err:?}"))
 }
 
 pub(crate) fn new_deserialize_metadata_error(
@@ -46,17 +38,9 @@ pub(crate) fn new_deserialize_metadata_error(
     op: Operation,
     path: &str,
 ) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("deserialize metadata: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("deserialize metadata: {err:?}"))
 }
 
 pub(crate) fn new_exec_async_cmd_error(err: RedisError, op: Operation, path: &str) -> Error {
-    other(ObjectError::new(
-        op,
-        path,
-        anyhow!("executing async command: {err:?}"),
-    ))
+    new_other_object_error(op, path, anyhow!("executing async command: {err:?}"))
 }

--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -31,8 +31,8 @@ use time::OffsetDateTime;
 
 use super::error::parse_error;
 use super::Backend;
-use crate::error::other;
-use crate::error::ObjectError;
+use crate::error::new_other_object_error;
+
 use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
@@ -90,11 +90,11 @@ impl futures::Stream for DirStream {
                     }
 
                     let bs = resp.into_body().bytes().await.map_err(|e| {
-                        other(ObjectError::new(
+                        new_other_object_error(
                             Operation::List,
                             &path,
                             anyhow!("read body: {:?}", e),
-                        ))
+                        )
                     })?;
 
                     Ok(bs)
@@ -105,11 +105,11 @@ impl futures::Stream for DirStream {
             State::Sending(fut) => {
                 let bs = ready!(Pin::new(fut).poll(cx))?;
                 let output: Output = de::from_reader(bs.reader()).map_err(|e| {
-                    other(ObjectError::new(
+                    new_other_object_error(
                         Operation::List,
                         &self.path,
                         anyhow!("deserialize list_bucket output: {:?}", e),
-                    ))
+                    )
                 })?;
 
                 // Try our best to check whether this list is done.
@@ -166,11 +166,11 @@ impl futures::Stream for DirStream {
 
                     let dt = OffsetDateTime::parse(object.last_modified.as_str(), &Rfc3339)
                         .map_err(|e| {
-                            other(ObjectError::new(
+                            new_other_object_error(
                                 Operation::List,
                                 &self.path,
                                 anyhow!("parse last modified RFC3339 datetime: {e:?}"),
-                            ))
+                            )
                         })?;
                     de.set_last_modified(dt);
 


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

close: https://github.com/datafuselabs/opendal/issues/563

- I created 2 functions `new_other_object_error` and `new_other_backend_error` which could return a `io:Error` diectlly.

