### PR TITLE
feat: Make AccessorMetadata public so outer users can use

### DIFF
--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -399,7 +399,8 @@ impl AccessorMetadata {
         self.scheme
     }
 
-    pub(crate) fn set_scheme(&mut self, scheme: Scheme) -> &mut Self {
+    /// Set [`Scheme`] for backend.
+    pub fn set_scheme(&mut self, scheme: Scheme) -> &mut Self {
         self.scheme = scheme;
         self
     }
@@ -409,7 +410,10 @@ impl AccessorMetadata {
         &self.root
     }
 
-    pub(crate) fn set_root(&mut self, root: &str) -> &mut Self {
+    /// Set root for backend.
+    ///
+    /// Note: input root must be normalized.
+    pub fn set_root(&mut self, root: &str) -> &mut Self {
         self.root = root.to_string();
         self
     }
@@ -424,7 +428,8 @@ impl AccessorMetadata {
         &self.name
     }
 
-    pub(crate) fn set_name(&mut self, name: &str) -> &mut Self {
+    /// Set name of this backend.
+    pub fn set_name(&mut self, name: &str) -> &mut Self {
         self.name = name.to_string();
         self
     }
@@ -459,13 +464,13 @@ impl AccessorMetadata {
         self.capabilities.contains(AccessorCapability::Blocking)
     }
 
-    /// Set this function to private so that users can't access capabilities
-    /// directly.
-    pub(crate) fn capabilities(&self) -> FlagSet<AccessorCapability> {
+    /// Get backend's capabilities.
+    pub fn capabilities(&self) -> FlagSet<AccessorCapability> {
         self.capabilities
     }
 
-    pub(crate) fn set_capabilities(
+    /// Set capabilities for backend.
+    pub fn set_capabilities(
         &mut self,
         capabilities: impl Into<FlagSet<AccessorCapability>>,
     ) -> &mut Self {
@@ -476,7 +481,7 @@ impl AccessorMetadata {
 
 flags! {
     /// AccessorCapability describes accessor's advanced capability.
-    pub(crate) enum AccessorCapability: u32 {
+    pub enum AccessorCapability: u32 {
         /// Add this capability if service supports `read` and `stat`
         Read,
         /// Add this capability if service supports `write` and `delete`

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -55,7 +55,7 @@ pub enum Scheme {
     Redis,
     /// [s3][crate::services::s3]: AWS S3 alike services.
     S3,
-    /// Custom that allow users to implement services outside of OpenDAL.
+    /// Custom that allow users to implement services outside OpenDAL.
     ///
     /// # NOTE
     ///


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Make AccessorMetadata public so outer users can use

part of https://github.com/datafuselabs/opendal/issues/744