### PR TITLE
feat: Implement cached metadata for ObjectEntry

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -21,7 +21,7 @@ runs:
 
     - name: Doc check
       shell: bash
-      run: cargo doc --no-deps
+      run: cargo doc --no-deps --all-features
 
     - name: Install cargo-audit
       uses: actions-rs/cargo@v1

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -129,6 +129,7 @@ pub trait Accessor: Send + Sync + Debug {
     ///
     /// - `stat` empty path means stat backend's root path.
     /// - `stat` a path endswith "/" means stating a dir.
+    /// - `mode` and `content_length` must be set.
     async fn stat(&self, path: &str, args: OpStat) -> Result<ObjectMetadata> {
         let (_, _) = (path, args);
         unimplemented!()

--- a/src/io_util/walk.rs
+++ b/src/io_util/walk.rs
@@ -24,6 +24,7 @@ use futures::Future;
 
 use crate::Object;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 use crate::ObjectStreamer;
 
@@ -90,7 +91,12 @@ impl futures::Stream for TopDownWalker {
                     Some(o) => o,
                     None => return Poll::Ready(None),
                 };
-                let de = ObjectEntry::new(object.accessor(), ObjectMode::DIR, object.path());
+
+                let de = ObjectEntry::new(
+                    object.accessor(),
+                    object.path(),
+                    ObjectMetadata::new(ObjectMode::DIR),
+                );
                 let future = async move { object.list().await };
 
                 self.state = WalkTopDownState::Sending(Box::pin(future));
@@ -221,7 +227,11 @@ impl futures::Stream for BottomUpWalker {
                             .dirs
                             .pop()
                             .expect("dis streamer corresponding object must exist");
-                        let de = ObjectEntry::new(dob.accessor(), ObjectMode::DIR, dob.path());
+                        let de = ObjectEntry::new(
+                            dob.accessor(),
+                            dob.path(),
+                            ObjectMetadata::new(ObjectMode::DIR),
+                        );
                         Poll::Ready(Some(Ok(de)))
                     }
                 },

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -272,7 +272,12 @@ impl Iterator for ImmutableDir {
                     ObjectMode::FILE
                 };
 
-                Some(Ok(ObjectEntry::new(self.backend.clone(), mode, &path)))
+                // BUG: the content length could be wrong.
+                Some(Ok(ObjectEntry::new(
+                    self.backend.clone(),
+                    &path,
+                    ObjectMetadata::new(mode),
+                )))
             }
         }
     }
@@ -293,8 +298,8 @@ impl futures::Stream for ImmutableDir {
 
                 Poll::Ready(Some(Ok(ObjectEntry::new(
                     self.backend.clone(),
-                    mode,
                     &path,
+                    ObjectMetadata::new(mode),
                 ))))
             }
         }

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -272,7 +272,6 @@ impl Iterator for ImmutableDir {
                     ObjectMode::FILE
                 };
 
-                // BUG: the content length could be wrong.
                 Some(Ok(ObjectEntry::new(
                     self.backend.clone(),
                     &path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,9 @@ mod tests {
         assert_eq!(80, size_of::<AccessorMetadata>());
         assert_eq!(16, size_of::<Operator>());
         assert_eq!(16, size_of::<BatchOperator>());
-        assert_eq!(128, size_of::<ObjectEntry>());
+        assert_eq!(56, size_of::<ObjectEntry>());
         assert_eq!(40, size_of::<Object>());
-        assert_eq!(80, size_of::<ObjectMetadata>());
+        assert_eq!(88, size_of::<ObjectMetadata>());
         assert_eq!(1, size_of::<ObjectMode>());
         assert_eq!(64, size_of::<ObjectMultipart>());
         assert_eq!(32, size_of::<ObjectPart>());

--- a/src/object.rs
+++ b/src/object.rs
@@ -1517,19 +1517,19 @@ impl ObjectEntry {
         self.into()
     }
 
-    /// Return this dir entry's object mode.
+    /// Return this object entry's object mode.
     pub fn mode(&self) -> ObjectMode {
         self.meta.lock().expect("lock must succeed").mode
     }
 
-    /// Return this dir entry's id.
+    /// Return this object entry's id.
     ///
     /// The same with [`Object::id()`]
     pub fn id(&self) -> String {
         format!("{}{}", self.acc.metadata().root(), self.path)
     }
 
-    /// Return this dir entry's path.
+    /// Return this object entry's path.
     ///
     /// The same with [`Object::path()`]
     pub fn path(&self) -> &str {
@@ -1548,7 +1548,7 @@ impl ObjectEntry {
         self.path = path.to_string();
     }
 
-    /// Return this dir entry's name.
+    /// Return this object entry's name.
     ///
     /// The same with [`Object::name()`]
     pub fn name(&self) -> &str {
@@ -1568,7 +1568,7 @@ impl ObjectEntry {
         self.meta.lock().expect("lock must succeed").clone()
     }
 
-    /// Fetch metadata about this dir entry.
+    /// Fetch metadata about this object entry.
     ///
     /// The same with [`Object::blocking_metadata()`]
     pub fn blocking_metadata(&self) -> ObjectMetadata {

--- a/src/object.rs
+++ b/src/object.rs
@@ -930,7 +930,7 @@ impl Object {
 
     /// List current dir object.
     ///
-    /// This function will create a new [`DirStreamer`] handle to list objects.
+    /// This function will create a new [`ObjectStreamer`] handle to list objects.
     ///
     /// An error will be returned if object path doesn't end with `/`.
     ///
@@ -949,7 +949,7 @@ impl Object {
     /// let op = Operator::from_env(Scheme::Memory)?;
     /// let o = op.object("path/to/dir/");
     /// let mut ds = o.list().await?;
-    /// // DirStreamer implements `futures::Stream`
+    /// // ObjectStreamer implements `futures::Stream`
     /// while let Some(de) = ds.try_next().await? {
     ///     match de.mode() {
     ///         ObjectMode::FILE => {
@@ -978,7 +978,7 @@ impl Object {
 
     /// List current dir object.
     ///
-    /// This function will create a new [`DirIterator`] handle to list objects.
+    /// This function will create a new [`ObjectIterator`] handle to list objects.
     ///
     /// An error will be returned if object path doesn't end with `/`.
     ///
@@ -1508,7 +1508,7 @@ impl ObjectEntry {
         self
     }
 
-    /// Convert [`DirEntry`] into [`Object`].
+    /// Convert [`ObjectEntry`] into [`Object`].
     ///
     /// This function is the same with already implemented `From` trait.
     /// This function will make our users happier to avoid writing
@@ -1603,7 +1603,7 @@ impl ObjectEntry {
 
     /// The MD5 message digest of `ObjectEntry`'s corresponding object
     ///
-    /// `content_md5` is a prefetched metadata field in `DirEntry`
+    /// `content_md5` is a prefetched metadata field in `ObjectEntry`
     ///
     /// It doesn't mean this metadata field of object doesn't exist if `content_md5` is `None`.
     /// Then you have to call `ObjectEntry::metadata()` to get the metadata you want.
@@ -1621,12 +1621,12 @@ impl ObjectEntry {
         self.metadata().await.content_md5
     }
 
-    /// The last modified UTC datetime of `DirEntry`'s corresponding object
+    /// The last modified UTC datetime of `ObjectEntry`'s corresponding object
     ///
-    /// `last_modified` is a prefetched metadata field in `DirEntry`
+    /// `last_modified` is a prefetched metadata field in `ObjectEntry`
     ///
     /// It doesn't mean this metadata field of object doesn't exist if `last_modified` is `None`.
-    /// Then you have to call `DirEntry::metadata()` to get the metadata you want.
+    /// Then you have to call `ObjectEntry::metadata()` to get the metadata you want.
     pub async fn last_modified(&self) -> Option<OffsetDateTime> {
         if let Some(v) = self.meta.lock().expect("lock must succeed").last_modified {
             return Some(v);

--- a/src/object.rs
+++ b/src/object.rs
@@ -1561,6 +1561,7 @@ impl ObjectEntry {
             // We will ignore all errors happened during inner metadata.
             if let Ok(meta) = self.acc.stat(self.path(), OpStat::new()).await {
                 self.set_metadata(meta);
+                self.complete.store(true, Ordering::Relaxed);
             }
         }
 
@@ -1575,6 +1576,7 @@ impl ObjectEntry {
             // We will ignore all errors happened during inner metadata.
             if let Ok(meta) = self.acc.blocking_stat(self.path(), OpStat::new()) {
                 self.set_metadata(meta);
+                self.complete.store(true, Ordering::Relaxed);
             }
         }
 

--- a/src/services/azblob/dir_stream.rs
+++ b/src/services/azblob/dir_stream.rs
@@ -35,6 +35,7 @@ use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct DirStream {
@@ -73,10 +74,10 @@ impl futures::Stream for DirStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let backend = self.backend.clone();
         let root = self.root.clone();
+        let path = self.path.clone();
 
         match &mut self.state {
             State::Idle => {
-                let path = self.path.clone();
                 let next_marker = self.next_marker.clone();
 
                 let fut = async move {
@@ -128,8 +129,8 @@ impl futures::Stream for DirStream {
 
                         let de = ObjectEntry::new(
                             backend,
-                            ObjectMode::DIR,
                             &build_rel_path(&root, prefix),
+                            ObjectMetadata::new(ObjectMode::DIR),
                         );
 
                         return Poll::Ready(Some(Ok(de)));
@@ -148,26 +149,25 @@ impl futures::Stream for DirStream {
                         continue;
                     }
 
-                    let mut de = ObjectEntry::new(
-                        backend,
-                        ObjectMode::FILE,
-                        &build_rel_path(&root, &object.name),
-                    );
-
-                    de.set_etag(object.properties.etag.as_str());
-                    de.set_content_length(object.properties.content_length);
-                    de.set_content_md5(object.properties.content_md5.as_str());
-
-                    let dt =
-                        OffsetDateTime::parse(object.properties.last_modified.as_str(), &Rfc2822)
-                            .map_err(|e| {
-                            new_other_object_error(
-                                Operation::List,
-                                &self.path,
-                                anyhow!("parse last modified RFC2822 datetime: {e:?}"),
+                    let meta = ObjectMetadata::new(ObjectMode::FILE)
+                        .with_etag(object.properties.etag.as_str())
+                        .with_content_length(object.properties.content_length)
+                        .with_content_md5(object.properties.content_md5.as_str())
+                        .with_last_modified(
+                            OffsetDateTime::parse(
+                                object.properties.last_modified.as_str(),
+                                &Rfc2822,
                             )
-                        })?;
-                    de.set_last_modified(dt);
+                            .map_err(|e| {
+                                new_other_object_error(
+                                    Operation::List,
+                                    &path,
+                                    anyhow!("parse last modified RFC2822 datetime: {e:?}"),
+                                )
+                            })?,
+                        );
+
+                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.name), meta);
 
                     return Poll::Ready(Some(Ok(de)));
                 }

--- a/src/services/azblob/dir_stream.rs
+++ b/src/services/azblob/dir_stream.rs
@@ -131,7 +131,8 @@ impl futures::Stream for DirStream {
                             backend,
                             &build_rel_path(&root, prefix),
                             ObjectMetadata::new(ObjectMode::DIR),
-                        );
+                        )
+                        .with_complete();
 
                         return Poll::Ready(Some(Ok(de)));
                     }
@@ -167,7 +168,8 @@ impl futures::Stream for DirStream {
                             })?,
                         );
 
-                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.name), meta);
+                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.name), meta)
+                        .with_complete();
 
                     return Poll::Ready(Some(Ok(de)));
                 }

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -550,6 +550,7 @@ impl Accessor for Backend {
                         &format!("{}/", &path),
                         ObjectMetadata::new(ObjectMode::DIR),
                     )
+                    .with_complete()
                 } else {
                     ObjectEntry::new(acc.clone(), &path, ObjectMetadata::new(ObjectMode::Unknown))
                 };

--- a/src/services/fs/dir_stream.rs
+++ b/src/services/fs/dir_stream.rs
@@ -67,6 +67,7 @@ impl futures::Stream for DirStream {
                         &path,
                         ObjectMetadata::new(ObjectMode::FILE),
                     )
+                    .with_complete()
                 } else if file_type.is_dir() {
                     // Make sure we are returning the correct path.
                     ObjectEntry::new(

--- a/src/services/fs/dir_stream.rs
+++ b/src/services/fs/dir_stream.rs
@@ -18,13 +18,12 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-use time::OffsetDateTime;
-
 use super::error::parse_io_error;
 use super::Backend;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct DirStream {
@@ -62,28 +61,26 @@ impl futures::Stream for DirStream {
                 // the target file type.
                 let file_type = de.file_type()?;
 
-                let mut d = if file_type.is_file() {
-                    ObjectEntry::new(self.backend.clone(), ObjectMode::FILE, &path)
+                let d = if file_type.is_file() {
+                    ObjectEntry::new(
+                        self.backend.clone(),
+                        &path,
+                        ObjectMetadata::new(ObjectMode::FILE),
+                    )
                 } else if file_type.is_dir() {
                     // Make sure we are returning the correct path.
                     ObjectEntry::new(
                         self.backend.clone(),
-                        ObjectMode::DIR,
                         &format!("{}/", &path),
+                        ObjectMetadata::new(ObjectMode::DIR),
                     )
                 } else {
-                    ObjectEntry::new(self.backend.clone(), ObjectMode::Unknown, &path)
+                    ObjectEntry::new(
+                        self.backend.clone(),
+                        &path,
+                        ObjectMetadata::new(ObjectMode::Unknown),
+                    )
                 };
-
-                // metadata may not available on all platforms, it's ok not setting it here
-                if let Ok(metadata) = de.metadata() {
-                    d.set_content_length(metadata.len());
-                    // last_modified is not available in all platforms.
-                    // it's ok not setting it here.
-                    if let Ok(last_modified) = metadata.modified().map(OffsetDateTime::from) {
-                        d.set_last_modified(last_modified);
-                    }
-                }
 
                 Poll::Ready(Some(Ok(d)))
             }

--- a/src/services/fs/dir_stream.rs
+++ b/src/services/fs/dir_stream.rs
@@ -67,7 +67,6 @@ impl futures::Stream for DirStream {
                         &path,
                         ObjectMetadata::new(ObjectMode::FILE),
                     )
-                    .with_complete()
                 } else if file_type.is_dir() {
                     // Make sure we are returning the correct path.
                     ObjectEntry::new(
@@ -75,6 +74,7 @@ impl futures::Stream for DirStream {
                         &format!("{}/", &path),
                         ObjectMetadata::new(ObjectMode::DIR),
                     )
+                    .with_complete()
                 } else {
                     ObjectEntry::new(
                         self.backend.clone(),

--- a/src/services/ftp/dir_stream.rs
+++ b/src/services/ftp/dir_stream.rs
@@ -24,6 +24,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use suppaftp::list::File;
+use time::OffsetDateTime;
 
 use super::err::parse_io_error;
 use super::Backend;
@@ -89,7 +90,9 @@ impl futures::Stream for DirStream {
                     ObjectEntry::new(
                         self.backend.clone(),
                         &path,
-                        ObjectMetadata::new(ObjectMode::FILE),
+                        ObjectMetadata::new(ObjectMode::FILE)
+                            .with_content_length(de.size() as u64)
+                            .with_last_modified(OffsetDateTime::from(de.modified())),
                     )
                 } else if de.is_directory() {
                     ObjectEntry::new(
@@ -97,6 +100,7 @@ impl futures::Stream for DirStream {
                         &format!("{}/", &path),
                         ObjectMetadata::new(ObjectMode::DIR),
                     )
+                    .with_complete()
                 } else {
                     ObjectEntry::new(
                         self.backend.clone(),

--- a/src/services/ftp/dir_stream.rs
+++ b/src/services/ftp/dir_stream.rs
@@ -29,6 +29,7 @@ use super::err::parse_io_error;
 use super::Backend;
 use crate::ops::Operation;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct ReadDir {
@@ -85,15 +86,23 @@ impl futures::Stream for DirStream {
                 let path = self.path.to_string() + de.name();
 
                 let d = if de.is_file() {
-                    ObjectEntry::new(self.backend.clone(), ObjectMode::FILE, &path)
+                    ObjectEntry::new(
+                        self.backend.clone(),
+                        &path,
+                        ObjectMetadata::new(ObjectMode::FILE),
+                    )
                 } else if de.is_directory() {
                     ObjectEntry::new(
                         self.backend.clone(),
-                        ObjectMode::DIR,
                         &format!("{}/", &path),
+                        ObjectMetadata::new(ObjectMode::DIR),
                     )
                 } else {
-                    ObjectEntry::new(self.backend.clone(), ObjectMode::Unknown, &path)
+                    ObjectEntry::new(
+                        self.backend.clone(),
+                        &path,
+                        ObjectMetadata::new(ObjectMode::Unknown),
+                    )
                 };
 
                 Poll::Ready(Some(Ok(d)))

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -310,16 +310,12 @@ impl Accessor for Backend {
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
         // Stat root always returns a DIR.
         if path == "/" {
-            let mut m = ObjectMetadata::default();
-            m.set_mode(ObjectMode::DIR);
-
-            return Ok(m);
+            return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
         let resp = self.gcs_get_object_metadata(path).await?;
 
         if resp.status().is_success() {
-            let mut m = ObjectMetadata::default();
             // read http response body
             let slc = resp.into_body().bytes().await.map_err(|e| {
                 new_other_object_error(Operation::Stat, path, anyhow!("read response body: {e:?}"))
@@ -331,6 +327,13 @@ impl Accessor for Backend {
                     anyhow!("parse response body into JSON: {e:?}"),
                 )
             })?;
+
+            let mode = if path.ends_with('/') {
+                ObjectMode::DIR
+            } else {
+                ObjectMode::FILE
+            };
+            let mut m = ObjectMetadata::new(mode);
 
             m.set_etag(&meta.etag);
             m.set_content_md5(&meta.md5_hash);
@@ -349,18 +352,9 @@ impl Accessor for Backend {
             })?;
             m.set_last_modified(datetime);
 
-            if path.ends_with('/') {
-                m.set_mode(ObjectMode::DIR);
-            } else {
-                m.set_mode(ObjectMode::FILE);
-            };
-
             Ok(m)
         } else if resp.status() == StatusCode::NOT_FOUND && path.ends_with('/') {
-            let mut m = ObjectMetadata::default();
-            m.set_mode(ObjectMode::DIR);
-
-            Ok(m)
+            Ok(ObjectMetadata::new(ObjectMode::DIR))
         } else {
             let er = parse_error_response(resp).await?;
             let e = parse_error(Operation::Stat, path, er);

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -272,12 +272,14 @@ impl Accessor for Backend {
             .metadata(&p)
             .map_err(|e| parse_io_error(e, Operation::Stat, path))?;
 
-        let mut m = ObjectMetadata::default();
-        if meta.is_dir() {
-            m.set_mode(ObjectMode::DIR);
+        let mode = if meta.is_dir() {
+            ObjectMode::DIR
         } else if meta.is_file() {
-            m.set_mode(ObjectMode::FILE);
-        }
+            ObjectMode::FILE
+        } else {
+            ObjectMode::Unknown
+        };
+        let mut m = ObjectMetadata::new(mode);
         m.set_content_length(meta.len());
         m.set_last_modified(OffsetDateTime::from(meta.modified()));
 

--- a/src/services/hdfs/dir_stream.rs
+++ b/src/services/hdfs/dir_stream.rs
@@ -61,6 +61,7 @@ impl futures::Stream for DirStream {
                         &format!("{}/", path),
                         ObjectMetadata::new(ObjectMode::DIR),
                     )
+                    .with_complete()
                 } else {
                     ObjectEntry::new(
                         self.backend.clone(),

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -186,10 +186,7 @@ impl Accessor for Backend {
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
         // Stat root always returns a DIR.
         if path == "/" {
-            let mut m = ObjectMetadata::default();
-            m.set_mode(ObjectMode::DIR);
-
-            return Ok(m);
+            return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
         let resp = self.http_head(path).await?;
@@ -198,7 +195,12 @@ impl Accessor for Backend {
 
         match status {
             StatusCode::OK => {
-                let mut m = ObjectMetadata::default();
+                let mode = if path.ends_with('/') {
+                    ObjectMode::DIR
+                } else {
+                    ObjectMode::FILE
+                };
+                let mut m = ObjectMetadata::new(mode);
 
                 if let Some(v) = parse_content_length(resp.headers())
                     .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
@@ -224,21 +226,12 @@ impl Accessor for Backend {
                     m.set_last_modified(v);
                 }
 
-                if path.ends_with('/') {
-                    m.set_mode(ObjectMode::DIR);
-                } else {
-                    m.set_mode(ObjectMode::FILE);
-                };
-
                 Ok(m)
             }
             // HTTP Server like nginx could return FORBIDDEN if auto-index
             // is not enabled, we should ignore them.
             StatusCode::NOT_FOUND | StatusCode::FORBIDDEN if path.ends_with('/') => {
-                let mut m = ObjectMetadata::default();
-                m.set_mode(ObjectMode::DIR);
-
-                Ok(m)
+                Ok(ObjectMetadata::new(ObjectMode::DIR))
             }
             _ => {
                 let er = parse_error_response(resp).await?;

--- a/src/services/ipmfs/backend.rs
+++ b/src/services/ipmfs/backend.rs
@@ -175,10 +175,7 @@ impl Accessor for Backend {
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
         // Stat root always returns a DIR.
         if path == "/" {
-            let mut m = ObjectMetadata::default();
-            m.set_mode(ObjectMode::DIR);
-
-            return Ok(m);
+            return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
         let resp = self.ipmfs_stat(path).await?;
@@ -201,12 +198,13 @@ impl Accessor for Backend {
                     )
                 })?;
 
-                let mut meta = ObjectMetadata::default();
-                meta.set_mode(match res.file_type.as_str() {
+                let mode = match res.file_type.as_str() {
                     "file" => ObjectMode::FILE,
                     "directory" => ObjectMode::DIR,
                     _ => ObjectMode::Unknown,
-                });
+                };
+
+                let mut meta = ObjectMetadata::new(mode);
                 meta.set_content_length(res.size);
 
                 Ok(meta)

--- a/src/services/ipmfs/dir_stream.rs
+++ b/src/services/ipmfs/dir_stream.rs
@@ -130,7 +130,8 @@ impl futures::Stream for DirStream {
                         backend,
                         &path,
                         ObjectMetadata::new(object.mode()).with_content_length(object.size),
-                    );
+                    )
+                    .with_complete();
                     return Poll::Ready(Some(Ok(de)));
                 }
 

--- a/src/services/ipmfs/dir_stream.rs
+++ b/src/services/ipmfs/dir_stream.rs
@@ -33,6 +33,7 @@ use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct DirStream {
@@ -123,8 +124,13 @@ impl futures::Stream for DirStream {
                         }
                         ObjectMode::Unknown => unreachable!(),
                     };
+
                     let path = build_rel_path(&root, &path);
-                    let de = ObjectEntry::new(backend, object.mode(), &path);
+                    let de = ObjectEntry::new(
+                        backend,
+                        &path,
+                        ObjectMetadata::new(object.mode()).with_content_length(object.size),
+                    );
                     return Poll::Ready(Some(Ok(de)));
                 }
 

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -155,10 +155,7 @@ impl Accessor for Backend {
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
         if path.ends_with('/') {
-            let mut meta = ObjectMetadata::default();
-            meta.set_mode(ObjectMode::DIR);
-
-            return Ok(meta);
+            return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
         let map = self.inner.lock();
@@ -170,9 +167,7 @@ impl Accessor for Backend {
             )
         })?;
 
-        let mut meta = ObjectMetadata::default();
-        meta.set_mode(ObjectMode::FILE)
-            .set_content_length(data.len() as u64);
+        let meta = ObjectMetadata::new(ObjectMode::FILE).with_content_length(data.len() as u64);
 
         Ok(meta)
     }
@@ -299,9 +294,17 @@ impl futures::Stream for DirStream {
         let path = self.paths.get(idx).expect("path must valid");
 
         let de = if path.ends_with('/') {
-            ObjectEntry::new(self.backend.clone(), ObjectMode::DIR, path)
+            ObjectEntry::new(
+                self.backend.clone(),
+                path,
+                ObjectMetadata::new(ObjectMode::DIR),
+            )
         } else {
-            ObjectEntry::new(self.backend.clone(), ObjectMode::FILE, path)
+            ObjectEntry::new(
+                self.backend.clone(),
+                path,
+                ObjectMetadata::new(ObjectMode::FILE),
+            )
         };
 
         Poll::Ready(Some(Ok(de)))

--- a/src/services/memory/backend.rs
+++ b/src/services/memory/backend.rs
@@ -299,6 +299,7 @@ impl futures::Stream for DirStream {
                 path,
                 ObjectMetadata::new(ObjectMode::DIR),
             )
+            .with_complete()
         } else {
             ObjectEntry::new(
                 self.backend.clone(),

--- a/src/services/obs/dir_stream.rs
+++ b/src/services/obs/dir_stream.rs
@@ -33,6 +33,7 @@ use crate::path::build_rel_path;
 use crate::services::obs::error::parse_error;
 use crate::services::obs::Backend;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct DirStream {
@@ -119,8 +120,8 @@ impl futures::Stream for DirStream {
 
                         let de = ObjectEntry::new(
                             backend,
-                            ObjectMode::DIR,
                             &build_rel_path(&root, prefix),
+                            ObjectMetadata::new(ObjectMode::DIR),
                         );
 
                         return Poll::Ready(Some(Ok(de)));
@@ -136,11 +137,10 @@ impl futures::Stream for DirStream {
                         continue;
                     }
 
-                    let de = ObjectEntry::new(
-                        backend,
-                        ObjectMode::FILE,
-                        &build_rel_path(&root, &object.key),
-                    );
+                    let meta =
+                        ObjectMetadata::new(ObjectMode::FILE).with_content_length(object.size);
+
+                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.key), meta);
 
                     return Poll::Ready(Some(Ok(de)));
                 }

--- a/src/services/obs/dir_stream.rs
+++ b/src/services/obs/dir_stream.rs
@@ -122,7 +122,8 @@ impl futures::Stream for DirStream {
                             backend,
                             &build_rel_path(&root, prefix),
                             ObjectMetadata::new(ObjectMode::DIR),
-                        );
+                        )
+                        .with_complete();
 
                         return Poll::Ready(Some(Ok(de)));
                     }

--- a/src/services/redis/backend.rs
+++ b/src/services/redis/backend.rs
@@ -254,8 +254,7 @@ impl Backend {
     ///
     /// Note: `to_create` have to be an absolute path.
     async fn mkdir_current(con: &mut ConnectionManager, to_create: &str, path: &str) -> Result<()> {
-        let mut metadata = ObjectMetadata::default();
-        metadata.set_mode(ObjectMode::DIR);
+        let metadata = ObjectMetadata::new(ObjectMode::DIR);
 
         let to_create = if !to_create.ends_with('/') {
             to_create.to_string() + "/"
@@ -364,8 +363,7 @@ impl Accessor for Backend {
             .map_err(|e| new_async_connection_error(e, Operation::Create, path.as_str()))?;
 
         // create current dir
-        let mut meta = ObjectMetadata::default();
-        meta.set_mode(args.mode());
+        let mut meta = ObjectMetadata::new(args.mode());
         if args.mode() == ObjectMode::FILE {
             // only set last_modified for files
             let last_modified = OffsetDateTime::now_utc();
@@ -449,12 +447,9 @@ impl Accessor for Backend {
 
         let m_path = v0_meta_prefix(abs_path.as_str());
 
-        let mut meta = ObjectMetadata::default();
-        let mode = ObjectMode::FILE;
-        let last_modified = OffsetDateTime::now_utc();
+        let mut meta = ObjectMetadata::new(ObjectMode::FILE);
         meta.set_content_length(content_length as u64);
-        meta.set_mode(mode);
-        meta.set_last_modified(last_modified);
+        meta.set_last_modified(OffsetDateTime::now_utc());
 
         // serialize and write to redis backend
         let bin = bincode::serialize(&meta)
@@ -553,8 +548,7 @@ mod redis_test {
     // this function is used for generating testing binary data
     #[test]
     fn test_generate_bincode() {
-        let mut meta = ObjectMetadata::default();
-        meta.set_mode(ObjectMode::DIR);
+        let mut meta = ObjectMetadata::new(ObjectMode::DIR);
         println!(
             "serialized directory metadata: {:?}",
             bincode::serialize(&meta).unwrap()

--- a/src/services/redis/dir_stream.rs
+++ b/src/services/redis/dir_stream.rs
@@ -28,6 +28,7 @@ use crate::ops::Operation;
 use crate::services::redis::backend::Backend;
 use crate::services::redis::error::new_exec_async_cmd_error;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 enum State {
@@ -107,7 +108,7 @@ impl Stream for DirStream {
                         ObjectMode::FILE
                     };
 
-                    let entry = ObjectEntry::new(backend, mode, path.as_str());
+                    let entry = ObjectEntry::new(backend, path.as_str(), ObjectMetadata::new(mode));
                     Poll::Ready(Some(Ok(entry)))
                 } else {
                     self.state = State::Idle;

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -900,10 +900,7 @@ impl Accessor for Backend {
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
         // Stat root always returns a DIR.
         if path == "/" {
-            let mut m = ObjectMetadata::default();
-            m.set_mode(ObjectMode::DIR);
-
-            return Ok(m);
+            return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
         let resp = self.head_object(path).await?;
@@ -912,7 +909,12 @@ impl Accessor for Backend {
 
         match status {
             StatusCode::OK => {
-                let mut m = ObjectMetadata::default();
+                let mode = if path.ends_with('/') {
+                    ObjectMode::DIR
+                } else {
+                    ObjectMode::FILE
+                };
+                let mut m = ObjectMetadata::new(mode);
 
                 if let Some(v) = parse_content_length(resp.headers())
                     .map_err(|e| new_other_object_error(Operation::Stat, path, e))?
@@ -933,19 +935,10 @@ impl Accessor for Backend {
                     m.set_last_modified(v);
                 }
 
-                if path.ends_with('/') {
-                    m.set_mode(ObjectMode::DIR);
-                } else {
-                    m.set_mode(ObjectMode::FILE);
-                };
-
                 Ok(m)
             }
             StatusCode::NOT_FOUND if path.ends_with('/') => {
-                let mut m = ObjectMetadata::default();
-                m.set_mode(ObjectMode::DIR);
-
-                Ok(m)
+                Ok(ObjectMetadata::new(ObjectMode::DIR))
             }
             _ => {
                 let er = parse_error_response(resp).await?;

--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -36,6 +36,7 @@ use crate::http_util::parse_error_response;
 use crate::ops::Operation;
 use crate::path::build_rel_path;
 use crate::ObjectEntry;
+use crate::ObjectMetadata;
 use crate::ObjectMode;
 
 pub struct DirStream {
@@ -74,10 +75,10 @@ impl futures::Stream for DirStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let backend = self.backend.clone();
         let root = self.root.clone();
+        let path = self.path.clone();
 
         match &mut self.state {
             State::Idle => {
-                let path = self.path.clone();
                 let token = self.token.clone();
                 let fut = async move {
                     let resp = backend.list_objects(&path, &token).await?;
@@ -106,7 +107,7 @@ impl futures::Stream for DirStream {
                 let output: Output = de::from_reader(bs.reader()).map_err(|e| {
                     new_other_object_error(
                         Operation::List,
-                        &self.path,
+                        &path,
                         anyhow!("deserialize list_bucket output: {:?}", e),
                     )
                 })?;
@@ -135,8 +136,12 @@ impl futures::Stream for DirStream {
                     *common_prefixes_idx += 1;
                     let prefix = &prefixes[*common_prefixes_idx - 1].prefix;
 
-                    let de =
-                        ObjectEntry::new(backend, ObjectMode::DIR, &build_rel_path(&root, prefix));
+                    let de = ObjectEntry::new(
+                        backend,
+                        &build_rel_path(&root, prefix),
+                        ObjectMetadata::new(ObjectMode::DIR),
+                    )
+                    .with_complete();
 
                     return Poll::Ready(Some(Ok(de)));
                 }
@@ -153,25 +158,23 @@ impl futures::Stream for DirStream {
                         continue;
                     }
 
-                    let mut de = ObjectEntry::new(
-                        backend,
-                        ObjectMode::FILE,
-                        &build_rel_path(&root, &object.key),
-                    );
+                    let mut meta = ObjectMetadata::new(ObjectMode::FILE);
 
                     // record metadata
-                    de.set_etag(object.etag.clone().trim_matches('\"'));
-                    de.set_content_length(object.size);
+                    meta.set_etag(&object.etag);
+                    meta.set_content_length(object.size);
 
                     let dt = OffsetDateTime::parse(object.last_modified.as_str(), &Rfc3339)
                         .map_err(|e| {
                             new_other_object_error(
                                 Operation::List,
-                                &self.path,
+                                &path,
                                 anyhow!("parse last modified RFC3339 datetime: {e:?}"),
                             )
                         })?;
-                    de.set_last_modified(dt);
+                    meta.set_last_modified(dt);
+
+                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.key), meta);
 
                     return Poll::Ready(Some(Ok(de)));
                 }

--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -174,7 +174,8 @@ impl futures::Stream for DirStream {
                         })?;
                     meta.set_last_modified(dt);
 
-                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.key), meta);
+                    let de = ObjectEntry::new(backend, &build_rel_path(&root, &object.key), meta)
+                        .with_complete();
 
                     return Poll::Ready(Some(Ok(de)));
                 }

--- a/tests/behavior/blocking_list.rs
+++ b/tests/behavior/blocking_list.rs
@@ -86,7 +86,7 @@ pub fn test_list_dir(op: Operator) -> Result<()> {
     let mut found = false;
     for de in obs {
         let de = de?;
-        let meta = de.blocking_metadata()?;
+        let meta = de.blocking_metadata();
         if de.path() == path {
             assert_eq!(meta.mode(), ObjectMode::FILE);
             assert_eq!(meta.content_length(), size as u64);

--- a/tests/behavior/list.rs
+++ b/tests/behavior/list.rs
@@ -100,7 +100,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
     let mut obs = op.object("/").list().await?;
     let mut found = false;
     while let Some(de) = obs.try_next().await? {
-        let meta = de.metadata().await?;
+        let meta = de.metadata().await;
         if de.path() == path {
             assert_eq!(meta.mode(), ObjectMode::FILE);
             assert_eq!(meta.content_length(), size as u64);
@@ -210,7 +210,7 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
         .get(&file_path)
         .expect("file should be found in list")
         .metadata()
-        .await?;
+        .await;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -219,7 +219,7 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
         .get(&dir_path)
         .expect("file should be found in list")
         .metadata()
-        .await?;
+        .await;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&file_path)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Implement cached metadata for ObjectEntry

After this PR, our users can full use our metadata stored during list.