### PR TITLE
docs: Fix wrong link to object_store

### DIFF
--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -9,4 +9,4 @@ All documents listed should be treated as highly biased. Because:
 
 Let's see OpenDAL:
 
-- [vs object_store](./object_store/)
+- [vs object_store](./object_store.html)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

docs: Fix wrong link to object_store
