### PR TITLE
fix(services/s3): Content MD5 not set during list

### DIFF
--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -160,8 +160,8 @@ impl futures::Stream for DirStream {
 
                     let mut meta = ObjectMetadata::new(ObjectMode::FILE);
 
-                    // record metadata
                     meta.set_etag(&object.etag);
+                    meta.set_content_md5(object.etag.trim_matches('"'));
                     meta.set_content_length(object.size);
 
                     let dt = OffsetDateTime::parse(object.last_modified.as_str(), &Rfc3339)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/s3): Content MD5 not set during list
