### PR TITLE
ci: Enable IPFS NoFecth to avoid networking timeout

### DIFF
--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -9,9 +9,6 @@ on:
       - main
     paths-ignore:
       - "docs/**"
-  # Run this test every hour to keep our testdata warm in ipfs network.
-  schedule:
-    - cron: "0 * * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           # ipfs v0.15 seems can't pass our tests, need investigate.
           ipfs_version: "v0.14.0"
-          run_daemon: true
+      - name: Start IPFS Daemon
+        run: |
+          ipfs config --json Gateway.NoFetch true
+          ipfs daemon &
       - name: IPFS add speed up tests
         run: ipfs add -r ./testdata
 

--- a/src/services/ipfs/error.rs
+++ b/src/services/ipfs/error.rs
@@ -35,6 +35,8 @@ pub fn parse_error(op: Operation, path: &str, er: ErrorResponse) -> Error {
         | StatusCode::BAD_GATEWAY
         | StatusCode::SERVICE_UNAVAILABLE
         | StatusCode::GATEWAY_TIMEOUT => ErrorKind::Interrupted,
+        // IPFS Gateway will return `408 REQUEST_TIMEOUT` while `ipfs resolve -r` failed.
+        StatusCode::REQUEST_TIMEOUT => ErrorKind::Interrupted,
         _ => ErrorKind::Other,
     };
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Fix #779 
