### PR TITLE
ci: Build all feature in release to prevent build failure under release profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           hdfs-version: "3.3.2"
 
       - name: Build
-        run: cargo build --all-features
+        run: cargo build --all-features --release
 
   unit:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Build all feature in release to prevent build failure under release profile
