### PR TITLE
fix(services/ipfs): Use ipfs files API to copy data

### DIFF
--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ipfs daemon &
       - name: IPFS Add testdata
-        run: ipfs add -r ./testdata --to-files /opendal-testdata
+        run: ipfs files cp ./testdata /opendal-testdata
 
       - name: Test
         shell: bash

--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           ipfs daemon &
       - name: IPFS Add testdata
-        run: ipfs files cp ./testdata /opendal-testdata
+        run: |
+          ipfs add -r ./testdata --to-files /opendal-testdata
+          ipfs files ls /opendal-testdata
 
       - name: Test
         shell: bash

--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: IPFS Add testdata
         run: |
           ipfs add -r ./testdata --to-files /opendal-testdata
-          ipfs files ls /opendal-testdata
+          ipfs files ls /opendal-testdata -l
 
       - name: Test
         shell: bash

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -334,6 +334,10 @@ impl Accessor for Backend {
                     } else {
                         m.set_mode(ObjectMode::FILE);
                     }
+                } else {
+                    // Some service will stream the output of DirIndex.
+                    // If we don't have an etag, it's highly to be a dir.
+                    m.set_mode(ObjectMode::DIR);
                 }
 
                 Ok(m)


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/ipfs): Use ipfs files API to copy data
