### PR TITLE
test: accelerate behaviour test `test_list_rich_dir`

### DIFF
--- a/.github/workflows/service_test_ftp.yml
+++ b/.github/workflows/service_test_ftp.yml
@@ -23,12 +23,12 @@ jobs:
         image: fauria/vsftpd
         ports:
           - 2121:21
-          - 21000-22000:21000-22000
+          - 20000-22000:20000-22000
         env:
           FTP_USER: admin
           FTP_PASS: admin
           PASV_ADDRESS: 127.0.0.1
-          PASV_MIN_PORT: 21000
+          PASV_MIN_PORT: 20000
           PASV_MAX_PORT: 22000
         volumes:
           - vsftpd-data:/home/vsftpd

--- a/src/services/ftp/err.rs
+++ b/src/services/ftp/err.rs
@@ -31,10 +31,12 @@ pub fn new_request_connection_err(e: FtpError, op: Operation, path: &str) -> Err
         // Allow retry for error
         //
         // `{ status: NotAvailable, body: "421 There are too many connections from your internet address." }`
-        FtpError::UnexpectedResponse(resp) if resp.status == Status::NotAvailable => Error::new(
-            ErrorKind::Interrupted,
-            ObjectError::new(op, path, anyhow!("connection request: {e:?}")),
-        ),
+        FtpError::UnexpectedResponse(ref resp) if resp.status == Status::NotAvailable => {
+            Error::new(
+                ErrorKind::Interrupted,
+                ObjectError::new(op, path, anyhow!("connection request: {e:?}")),
+            )
+        }
         _ => new_other_object_error(op, path, anyhow!("connection request: {e:?}")),
     }
 }

--- a/tests/behavior/list.rs
+++ b/tests/behavior/list.rs
@@ -123,8 +123,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
 
 /// listing a directory, which contains more objects than a single page can take.
 pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
-    let files = 1000;
-    let mut expected: Vec<String> = (0..=files)
+    let mut expected: Vec<String> = (0..=1000)
         .map(|num| format!("test_list_rich_dir/file-{}", num))
         .collect();
     let mut futs = FuturesUnordered::new();

--- a/tests/behavior/list.rs
+++ b/tests/behavior/list.rs
@@ -123,6 +123,11 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
 
 /// listing a directory, which contains more objects than a single page can take.
 pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
+    // Create dir first to avoid concurrent create parent.
+    //
+    // Should be removed after <https://github.com/datafuselabs/opendal/issues/829>
+    op.object("test_list_rich_dir/").create().await?;
+
     let mut expected: Vec<String> = (0..=1000)
         .map(|num| format!("test_list_rich_dir/file-{}", num))
         .collect();


### PR DESCRIPTION
Signed-off-by: ClSlaid <cailue@bupt.edu.cn>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Initialization of the test is too slow, this PR saves time by fully parallelise creating procedure.

That's why we introduce async/await, isn't it?

- before
elapsed: 43.692s

![图片](https://user-images.githubusercontent.com/44747719/194748134-d82fb7e8-7bb1-4d4a-8c40-d3eb2a34cc26.png)

- after
elapsed: 24.249s
![图片](https://user-images.githubusercontent.com/44747719/194748211-1a7f5b9f-704f-4d0c-9954-cb9f8d094758.png)
