### PR TITLE
fix: ObjectEntry returned in batch operator doesn't have corrent accessor

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -233,6 +233,7 @@ impl Operator {
         }
     }
 
+    /// Get inner accessor.
     fn inner(&self) -> Arc<dyn Accessor> {
         self.accessor.clone()
     }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: ObjectEntry returned in batch operator doesn't have corrent accessor
