### PR TITLE
feat(experiment): add a basic content data cache layer

### DIFF
--- a/docs/comparisons/object_store.md
+++ b/docs/comparisons/object_store.md
@@ -103,6 +103,7 @@ opendal supports:
 - ImmutableIndexLayer: immutable in-memory index.
 - LoggingLayer: logging.
 - MetadataCacheLayer: metadata cache.
+- ContentCacheLayer: content data cache.
 - MetricsLayer: metrics
 - RetryLayer: retry
 - SubdirLayer: Allow switch directory without changing original operator.

--- a/src/layers/content_cache.rs
+++ b/src/layers/content_cache.rs
@@ -1,0 +1,286 @@
+// Copyright 2022 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::io::ErrorKind;
+use std::io::Result;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::util::set_accessor_for_object_iterator;
+use super::util::set_accessor_for_object_steamer;
+use crate::ops::OpAbortMultipart;
+use crate::ops::OpCompleteMultipart;
+use crate::ops::OpCreate;
+use crate::ops::OpCreateMultipart;
+use crate::ops::OpDelete;
+use crate::ops::OpList;
+use crate::ops::OpPresign;
+use crate::ops::OpRead;
+use crate::ops::OpStat;
+use crate::ops::OpWrite;
+use crate::ops::OpWriteMultipart;
+use crate::ops::PresignedRequest;
+use crate::Accessor;
+use crate::AccessorMetadata;
+use crate::BlockingBytesReader;
+use crate::BytesReader;
+use crate::Layer;
+use crate::ObjectIterator;
+use crate::ObjectMetadata;
+use crate::ObjectPart;
+use crate::ObjectStreamer;
+
+/// ContentCacheLayer will add content data cache support for OpenDAL.
+///
+/// # Notes
+///
+/// This layer only maintains its own states. Users should care about the cache
+/// consistency by themselves. For example, in the following situations, users
+/// could get out-dated metadata cache:
+///
+/// - Users have operations on underlying operator directly.
+/// - Other nodes have operations on underlying storage directly.
+/// - Concurrent read/write/delete on the same path.
+///
+/// To make sure content cache consistent across the cluster, please make sure
+/// all nodes in the cluster use the same cache services like redis or tikv.
+///
+/// # Examples
+///
+/// ```
+/// use anyhow::Result;
+/// use opendal::layers::ContentCacheLayer;
+/// use opendal::services::memory;
+/// use opendal::Operator;
+/// use opendal::Scheme;
+///
+/// let _ = Operator::from_env(Scheme::Fs)
+///     .expect("must init")
+///     .layer(ContentCacheLayer::new(
+///         memory::Builder::default().build().expect("must init"),
+///     ));
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContentCacheLayer {
+    cache: Arc<dyn Accessor>,
+}
+
+impl ContentCacheLayer {
+    /// Create a new metadata cache layer.
+    pub fn new(acc: impl Accessor + 'static) -> Self {
+        Self {
+            cache: Arc::new(acc),
+        }
+    }
+}
+
+impl Layer for ContentCacheLayer {
+    fn layer(&self, inner: Arc<dyn Accessor>) -> Arc<dyn Accessor> {
+        Arc::new(ContentCacheAccessor {
+            cache: self.cache.clone(),
+            inner,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ContentCacheAccessor {
+    cache: Arc<dyn Accessor>,
+    inner: Arc<dyn Accessor>,
+}
+
+#[async_trait]
+impl Accessor for ContentCacheAccessor {
+    fn metadata(&self) -> AccessorMetadata {
+        self.inner.metadata()
+    }
+
+    async fn create(&self, path: &str, args: OpCreate) -> Result<()> {
+        self.cache.delete(path, OpDelete::new()).await?;
+        self.inner.create(path, args).await
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<BytesReader> {
+        match self.cache.read(path, args.clone()).await {
+            Ok(r) => Ok(r),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let r = self.inner.read(path, args).await?;
+                let meta = self.inner.stat(path, OpStat::new()).await?;
+                if meta.mode().is_file() {
+                    let size = meta.content_length();
+                    let reader = self.inner.read(path, OpRead::new(..)).await?;
+                    self.cache.write(path, OpWrite::new(size), reader).await?;
+                }
+                Ok(r)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn write(&self, path: &str, args: OpWrite, r: BytesReader) -> Result<u64> {
+        self.cache.delete(path, OpDelete::new()).await?;
+        self.inner.write(path, args, r).await
+    }
+
+    async fn stat(&self, path: &str, args: OpStat) -> Result<ObjectMetadata> {
+        match self.cache.stat(path, OpStat::new()).await {
+            Ok(meta) => Ok(meta),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let meta = self.inner.stat(path, args).await?;
+                if meta.mode().is_file() {
+                    let size = meta.content_length();
+                    let reader = self.inner.read(path, OpRead::new(..)).await?;
+                    self.cache.write(path, OpWrite::new(size), reader).await?;
+                }
+                Ok(meta)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn delete(&self, path: &str, args: OpDelete) -> Result<()> {
+        self.cache.delete(path, OpDelete::new()).await?;
+        self.inner.delete(path, args).await
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<ObjectStreamer> {
+        self.inner
+            .list(path, args)
+            .await
+            .map(|s| set_accessor_for_object_steamer(s, self.clone()))
+    }
+
+    fn presign(&self, path: &str, args: OpPresign) -> Result<PresignedRequest> {
+        self.inner.presign(path, args)
+    }
+
+    async fn create_multipart(&self, path: &str, args: OpCreateMultipart) -> Result<String> {
+        self.inner.create_multipart(path, args).await
+    }
+
+    async fn write_multipart(
+        &self,
+        path: &str,
+        args: OpWriteMultipart,
+        r: BytesReader,
+    ) -> Result<ObjectPart> {
+        self.inner.write_multipart(path, args, r).await
+    }
+
+    async fn complete_multipart(&self, path: &str, args: OpCompleteMultipart) -> Result<()> {
+        self.inner.complete_multipart(path, args).await
+    }
+
+    async fn abort_multipart(&self, path: &str, args: OpAbortMultipart) -> Result<()> {
+        self.inner.abort_multipart(path, args).await
+    }
+
+    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<()> {
+        self.cache.blocking_delete(path, OpDelete::new())?;
+        self.inner.blocking_create(path, args)
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<BlockingBytesReader> {
+        match self.cache.blocking_read(path, args.clone()) {
+            Ok(r) => Ok(r),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let r = self.inner.blocking_read(path, args)?;
+                let meta = self.inner.blocking_stat(path, OpStat::new())?;
+                if meta.mode().is_file() {
+                    let size = meta.content_length();
+                    let reader = self.inner.blocking_read(path, OpRead::new(..))?;
+                    self.cache
+                        .blocking_write(path, OpWrite::new(size), reader)?;
+                }
+                Ok(r)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite, r: BlockingBytesReader) -> Result<u64> {
+        self.cache.blocking_delete(path, OpDelete::new())?;
+        self.inner.blocking_write(path, args, r)
+    }
+
+    fn blocking_stat(&self, path: &str, args: OpStat) -> Result<ObjectMetadata> {
+        match self.cache.blocking_stat(path, OpStat::new()) {
+            Ok(meta) => Ok(meta),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let meta = self.inner.blocking_stat(path, args)?;
+                if meta.mode().is_file() {
+                    let size = meta.content_length();
+                    let reader = self.inner.blocking_read(path, OpRead::new(..))?;
+                    self.cache
+                        .blocking_write(path, OpWrite::new(size), reader)?;
+                }
+                Ok(meta)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<()> {
+        self.cache.blocking_delete(path, OpDelete::new())?;
+        self.inner.blocking_delete(path, args)
+    }
+
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<ObjectIterator> {
+        self.inner
+            .blocking_list(path, args)
+            .map(|s| set_accessor_for_object_iterator(s, self.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::memory;
+    use crate::Operator;
+
+    #[tokio::test]
+    async fn test_content_cache() -> anyhow::Result<()> {
+        let op = Operator::new(memory::Builder::default().build()?);
+
+        let cache_layer = ContentCacheLayer::new(memory::Builder::default().build()?);
+        let cached_op = op.clone().layer(cache_layer);
+
+        // Write a new object into op.
+        op.object("test_exist")
+            .write("Hello, World!".as_bytes())
+            .await?;
+        // Stat from cached op.
+        let meta = cached_op.object("test_exist").metadata().await?;
+        assert_eq!(meta.content_length(), 13);
+
+        // Write into cache op.
+        cached_op
+            .object("test_exist")
+            .write("Hello, Xuanwo!".as_bytes())
+            .await?;
+        // op and cached op should have same data.
+        let meta = op.object("test_exist").metadata().await?;
+        assert_eq!(meta.content_length(), 14);
+        let meta = cached_op.object("test_exist").metadata().await?;
+        assert_eq!(meta.content_length(), 14);
+
+        // Stat not exist object.
+        let meta = cached_op.object("test_not_exist").metadata().await;
+        assert_eq!(meta.unwrap_err().kind(), ErrorKind::NotFound);
+
+        Ok(())
+    }
+}

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -19,6 +19,7 @@
 //! - [`ImmutableIndexLayer`]: Add an immutable in-memory index for OpenDAL.
 //! - [`LoggingLayer`]: Add logging for OpenDAL.
 //! - [`MetadataCacheLayer`]: Add metadata cache for OpenDAL.
+//! - [`ContentCacheLayer`]: Add content data cache for OpenDAL.
 //! - [`MetricsLayer`]: Add metrics for OpenDAL, requires feature `layers-metrics`
 //! - [`RetryLayer`]: Add retry for OpenDAL.
 //! - [`SubdirLayer`]: Allow OpenDAL to switch directory.
@@ -38,6 +39,9 @@ pub use logging::LoggingLayer;
 
 mod metadata_cache;
 pub use metadata_cache::MetadataCacheLayer;
+
+mod content_cache;
+pub use content_cache::ContentCacheLayer;
 
 #[cfg(feature = "layers-metrics")]
 mod metrics;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Access the cache on read only, and write to the cache if it is not hit but the data exists in underlying.

Something that needs further consideration is to limit the space available for caching and to provide a suitable cache eviction policy.
