### PR TITLE
fix: Retry for wirte is not implemented correctly

### DIFF
--- a/src/services/obs/error.rs
+++ b/src/services/obs/error.rs
@@ -35,6 +35,8 @@ pub fn parse_error(op: Operation, path: &str, er: ErrorResponse) -> Error {
         | StatusCode::BAD_GATEWAY
         | StatusCode::SERVICE_UNAVAILABLE
         | StatusCode::GATEWAY_TIMEOUT => ErrorKind::Interrupted,
+        // OBS could return `520 Origin Error` errors which should be retried.
+        v if v.as_u16() == 520 => ErrorKind::Interrupted,
         _ => ErrorKind::Other,
     };
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Retry for wirte is not implemented correctly

Related to https://github.com/datafuselabs/databend/issues/8188