### PR TITLE
refactor: replace md5 with md-5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ futures = { version = "0.3", features = ["alloc"] }
 hdrs = { version = "0.1", optional = true, features = ["futures-io"] }
 http = "0.2"
 log = "0.4"
-md5 = "0.7"
+md-5 = "0.10"
 metrics = { version = "0.20", optional = true }
 moka = { version = "0.9", optional = true, features = ["future"] }
 once_cell = "1"

--- a/oay/Cargo.lock
+++ b/oay/Cargo.lock
@@ -962,10 +962,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1096,7 +1099,7 @@ dependencies = [
  "futures",
  "http",
  "log",
- "md5",
+ "md-5",
  "once_cell",
  "parking_lot",
  "percent-encoding",

--- a/oli/Cargo.lock
+++ b/oli/Cargo.lock
@@ -701,10 +701,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -839,7 +842,7 @@ dependencies = [
  "futures",
  "http",
  "log",
- "md5",
+ "md-5",
  "once_cell",
  "parking_lot",
  "percent-encoding",

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -33,6 +33,7 @@ use http::StatusCode;
 use log::debug;
 use log::error;
 use log::info;
+use md5::{Digest, Md5};
 use once_cell::sync::Lazy;
 use reqsign::AwsV4Signer;
 use serde::Deserialize;
@@ -457,7 +458,7 @@ impl Builder {
         self.server_side_encryption_customer_algorithm = Some(algorithm.to_string());
         self.server_side_encryption_customer_key = Some(base64::encode(key));
         self.server_side_encryption_customer_key_md5 =
-            Some(base64::encode(md5::compute(key).as_slice()));
+            Some(base64::encode(Md5::digest(key).as_slice()));
         self
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

A very small change. However, md5 has not been updated for many years.


