### PR TITLE
refactor(layers/metrics): Holding all metrics handlers to avoid lock

### DIFF
--- a/src/layers/metrics.rs
+++ b/src/layers/metrics.rs
@@ -114,7 +114,7 @@ impl Layer for MetricsLayer {
 
 /// metrics will hold all metrics handlers in a `RwLock<Map>`.
 ///
-/// By holding all metrics hanlers we needed here, we can reduce the lock
+/// By holding all metrics handlers we needed, we can reduce the lock
 /// cost on fetching them. All metrics update will be atomic operations.
 #[derive(Clone)]
 struct MetricsHandler {


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor(layers/metrics): Holding all metrics handlers to avoid lock
