### PR TITLE
ci: Disable ipfs's compress integration tests

### DIFF
--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -24,9 +24,7 @@ jobs:
         id: ipfs_setup
         with:
           ipfs_version: "v0.16.0"
-      - name: Start IPFS Daemon
-        run: |
-          ipfs daemon &
+          run_daemon: true
       - name: IPFS Add testdata
         run: |
           ipfs add -r ./testdata --to-files /opendal-testdata
@@ -41,7 +39,6 @@ jobs:
           OPENDAL_IPFS_TEST: on
           OPENDAL_IPFS_ROOT: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/
           OPENDAL_IPFS_ENDPOINT: "http://127.0.0.1:8080"
-
 #  # ipfs.io can't pass our test by now, we should address them in the future.
 #  ipfs-io:
 #    runs-on: ubuntu-latest

--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: cargo test ipfs --features compress,layers-retry,services-ipfs -- --nocapture
+        run: cargo test ipfs --features layers-retry,services-ipfs -- --nocapture
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Debug ipfs integration tests
