### PR TITLE
refactor: use moka::sync::SegmentedCache

### DIFF
--- a/src/services/moka/backend.rs
+++ b/src/services/moka/backend.rs
@@ -148,7 +148,7 @@ impl Builder {
         debug!("backend build started: {:?}", &self);
 
         let mut builder: CacheBuilder<Vec<u8>, Vec<u8>, _> =
-            SegmentedCache::builder(self.num_segments.unwrap())
+            SegmentedCache::builder(self.num_segments.unwrap_or(1))
                 .thread_pool_enabled(self.thread_pool_enabled.unwrap_or(false));
         // Use entries's bytes as capacity weigher.
         builder = builder.weigher(|k, v| (k.len() + v.len()) as u32);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- [refactor: use moka::sync::SegmentedCache](https://github.com/datafuselabs/opendal/commit/588360c756a32177bb5a763c4c9f636ab3fc73af)
- [feat(services-moka): add option thread_pool_enabled](https://github.com/datafuselabs/opendal/commit/775770fa9f05c0f410fcca8d535d413a38194c50)
- [refactor(services-moka): make num_segments option](https://github.com/datafuselabs/opendal/commit/e4f9fb9de8b0f2f704af2c34529a513a857a1a8f)

Related: https://github.com/datafuselabs/databend/issues/8744