### PR TITLE
refactor(oay,oli): drop unnecessary `patch.crates-io` from `Cargo.toml`

### DIFF
--- a/oay/Cargo.toml
+++ b/oay/Cargo.toml
@@ -17,11 +17,7 @@ clap = { version = "4", features = ["cargo"] }
 env_logger = "0.9"
 futures = "0.3"
 log = "0.4"
-opendal = "0.19"
+opendal = { version = "0.19", path = "../" }
 percent-encoding = "2"
 sluice = "0.5"
 tokio = { version = "1.20", features = ["rt-multi-thread", "macros"] }
-
-# Please comment the following patch while releasing.
-[patch.crates-io]
-opendal = { path = "../" }

--- a/oli/Cargo.toml
+++ b/oli/Cargo.toml
@@ -15,13 +15,9 @@ anyhow = "1"
 clap = { version = "4", features = ["cargo", "string"] }
 env_logger = "0.9"
 log = "0.4"
-opendal = "0.19"
+opendal = { version = "0.19", path = "../" }
 tokio = { version = "1.20", features = ["fs", "macros", "rt-multi-thread"] }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "2"
-
-# Please comment the following patch while releasing.
-[patch.crates-io]
-opendal = { path = "../" }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Cargo is smart enough to handle [multiple locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations).
