### PR TITLE
feat: Make ObjectReader content_length returned for all services

### DIFF
--- a/src/http_util/header.rs
+++ b/src/http_util/header.rs
@@ -110,7 +110,9 @@ pub fn parse_etag(headers: &HeaderMap) -> Result<Option<&str>> {
 ///
 /// # Notes
 ///
-/// Services can implement their own parser logic based on this function.
+/// parse_into_object_metadata only handles the standard behavior of http
+/// headers. If services have their own logic, they should update the parsed
+/// metadata on demand.
 pub fn parse_into_object_metadata(
     op: Operation,
     path: &str,

--- a/src/http_util/header.rs
+++ b/src/http_util/header.rs
@@ -24,7 +24,11 @@ use http::HeaderMap;
 use time::format_description::well_known::Rfc2822;
 use time::OffsetDateTime;
 
+use crate::error::new_other_object_error;
 use crate::ops::BytesContentRange;
+use crate::ops::Operation;
+use crate::ObjectMetadata;
+use crate::ObjectMode;
 
 /// Parse content length from header map.
 pub fn parse_content_length(headers: &HeaderMap) -> Result<Option<u64>> {
@@ -100,4 +104,54 @@ pub fn parse_etag(headers: &HeaderMap) -> Result<Option<&str>> {
                 .map_err(|e| anyhow!("parse etag header: {:?}", e))?,
         )),
     }
+}
+
+/// parse_into_object_metadata will parse standards http headers into ObjectMetadata.
+///
+/// # Notes
+///
+/// Services can implement their own parser logic based on this function.
+pub fn parse_into_object_metadata(
+    op: Operation,
+    path: &str,
+    headers: &HeaderMap,
+) -> std::io::Result<ObjectMetadata> {
+    let mode = if path.ends_with('/') {
+        ObjectMode::DIR
+    } else {
+        ObjectMode::FILE
+    };
+    let mut m = ObjectMetadata::new(mode);
+
+    if let Some(v) =
+        parse_content_length(headers).map_err(|e| new_other_object_error(op, path, e))?
+    {
+        m.set_content_length(v);
+    }
+
+    if let Some(v) = parse_content_type(headers).map_err(|e| new_other_object_error(op, path, e))? {
+        m.set_content_type(v);
+    }
+
+    if let Some(v) =
+        parse_content_range(headers).map_err(|e| new_other_object_error(op, path, e))?
+    {
+        m.set_content_range(v);
+    }
+
+    if let Some(v) = parse_etag(headers).map_err(|e| new_other_object_error(op, path, e))? {
+        m.set_etag(v);
+    }
+
+    if let Some(v) = parse_content_md5(headers).map_err(|e| new_other_object_error(op, path, e))? {
+        m.set_content_md5(v);
+    }
+
+    if let Some(v) =
+        parse_last_modified(headers).map_err(|e| new_other_object_error(op, path, e))?
+    {
+        m.set_last_modified(v);
+    }
+
+    Ok(m)
 }

--- a/src/http_util/mod.rs
+++ b/src/http_util/mod.rs
@@ -33,6 +33,7 @@ pub use header::parse_content_md5;
 pub use header::parse_content_range;
 pub use header::parse_content_type;
 pub use header::parse_etag;
+pub use header::parse_into_object_metadata;
 pub use header::parse_last_modified;
 
 mod uri;

--- a/src/layers/content_cache.rs
+++ b/src/layers/content_cache.rs
@@ -227,14 +227,8 @@ impl AsyncRead for WholeCacheReader {
                             let r = inner.read(&path, OpRead::new()).await?;
 
                             let length = r.content_length();
-                            let size = if let Some(size) = length {
-                                size
-                            } else {
-                                let meta = inner.stat(&path, OpStat::new()).await?;
-                                meta.content_length()
-                            };
                             cache
-                                .write(&path, OpWrite::new(size), r.into_reader())
+                                .write(&path, OpWrite::new(length), r.into_reader())
                                 .await?;
                             cache.read(&path, args).await
                         }

--- a/src/layers/content_cache.rs
+++ b/src/layers/content_cache.rs
@@ -15,16 +15,9 @@
 use std::fmt::Debug;
 use std::io::ErrorKind;
 use std::io::Result;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::ready;
-use std::task::Context;
-use std::task::Poll;
 
 use async_trait::async_trait;
-use futures::future::BoxFuture;
-use futures::AsyncRead;
-use futures::FutureExt;
 
 use super::util::set_accessor_for_object_iterator;
 use super::util::set_accessor_for_object_steamer;
@@ -113,12 +106,7 @@ impl Accessor for ContentCacheAccessor {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<ObjectReader> {
-        Ok(ObjectReader::new(Box::new(WholeCacheReader::new(
-            self.inner.clone(),
-            self.cache.clone(),
-            path,
-            args,
-        ))))
+        WholeCacheReader::create(self.inner.clone(), self.cache.clone(), path, args).await
     }
 
     async fn write(&self, path: &str, args: OpWrite, r: BytesReader) -> Result<u64> {
@@ -180,71 +168,27 @@ impl Accessor for ContentCacheAccessor {
     }
 }
 
-struct WholeCacheReader {
-    inner: Arc<dyn Accessor>,
-    cache: Arc<dyn Accessor>,
-    state: WholeCacheState,
-
-    path: String,
-    args: OpRead,
-}
+struct WholeCacheReader;
 
 impl WholeCacheReader {
-    fn new(inner: Arc<dyn Accessor>, cache: Arc<dyn Accessor>, path: &str, args: OpRead) -> Self {
-        Self {
-            inner,
-            cache,
-            state: WholeCacheState::Idle,
-            path: path.to_string(),
-            args,
-        }
-    }
-}
+    async fn create(
+        inner: Arc<dyn Accessor>,
+        cache: Arc<dyn Accessor>,
+        path: &str,
+        args: OpRead,
+    ) -> Result<ObjectReader> {
+        match cache.read(path, args.clone()).await {
+            Ok(r) => Ok(r),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let r = inner.read(path, OpRead::new()).await?;
 
-enum WholeCacheState {
-    Idle,
-    Sending(BoxFuture<'static, Result<ObjectReader>>),
-    Reading(ObjectReader),
-}
-
-impl AsyncRead for WholeCacheReader {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<Result<usize>> {
-        match &mut self.state {
-            WholeCacheState::Idle => {
-                let cache = self.cache.clone();
-                let inner = self.inner.clone();
-                let path = self.path.clone();
-                let args = self.args.clone();
-
-                let fut = async move {
-                    match cache.read(&path, args.clone()).await {
-                        Ok(r) => Ok(r),
-                        Err(err) if err.kind() == ErrorKind::NotFound => {
-                            let r = inner.read(&path, OpRead::new()).await?;
-
-                            let length = r.content_length();
-                            cache
-                                .write(&path, OpWrite::new(length), r.into_reader())
-                                .await?;
-                            cache.read(&path, args).await
-                        }
-                        Err(err) => Err(err),
-                    }
-                };
-
-                self.state = WholeCacheState::Sending(Box::pin(fut));
-                self.poll_read(cx, buf)
+                let length = r.content_length();
+                cache
+                    .write(path, OpWrite::new(length), r.into_reader())
+                    .await?;
+                cache.read(path, args).await
             }
-            WholeCacheState::Sending(fut) => {
-                let r = ready!(fut.poll_unpin(cx))?;
-                self.state = WholeCacheState::Reading(r);
-                self.poll_read(cx, buf)
-            }
-            WholeCacheState::Reading(r) => Pin::new(r).poll_read(cx, buf),
+            Err(err) => Err(err),
         }
     }
 }

--- a/src/object/reader.rs
+++ b/src/object/reader.rs
@@ -73,8 +73,10 @@ impl ObjectReader {
     ///
     /// The content length returned here is the length of this read request.
     /// It's **different** from the object's content length.
-    pub fn content_length(&self) -> Option<u64> {
-        self.meta.content_length_raw()
+    pub fn content_length(&self) -> u64 {
+        self.meta
+            .content_length_raw()
+            .expect("object reader must have content length")
     }
 
     /// Last modified of this object.

--- a/src/object/reader.rs
+++ b/src/object/reader.rs
@@ -64,6 +64,18 @@ impl ObjectReader {
         self.inner
     }
 
+    /// Convert into parts.
+    ///
+    /// # Notes
+    ///
+    /// This function must be used **carefully**.
+    ///
+    /// The [`ObjectMetadata`] is **different** from the whole object's
+    /// metadata. It just described the corresbonding reader's metadata.
+    pub fn into_parts(self) -> (ObjectMetadata, BytesReader) {
+        (self.meta, self.inner)
+    }
+
     /// Content length of this object reader.
     ///
     /// `Content-Length` is defined by [RFC 7230](https://httpwg.org/specs/rfc7230.html#header.content-length)

--- a/src/ops/bytes_range.rs
+++ b/src/ops/bytes_range.rs
@@ -100,7 +100,7 @@ impl Display for BytesRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match (self.0, self.1) {
             (Some(offset), None) => write!(f, "{}-", offset),
-            (None, Some(size)) => write!(f, "-{}", size - 1),
+            (None, Some(size)) => write!(f, "-{}", size),
             (Some(offset), Some(size)) => write!(f, "{}-{}", offset, offset + size - 1),
             (None, None) => write!(f, "0-"),
         }
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_bytes_range_to_string() {
         let h = BytesRange::new(None, Some(1024));
-        assert_eq!(h.to_string(), "-1023");
+        assert_eq!(h.to_string(), "-1024");
 
         let h = BytesRange::new(Some(0), Some(1024));
         assert_eq!(h.to_string(), "0-1023");

--- a/src/ops/bytes_range.rs
+++ b/src/ops/bytes_range.rs
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_bytes_range_to_header() {
         let h = BytesRange::new(None, Some(1024));
-        assert_eq!(h.to_header(), "bytes=-1023");
+        assert_eq!(h.to_header(), "bytes=-1024");
 
         let h = BytesRange::new(Some(0), Some(1024));
         assert_eq!(h.to_header(), "bytes=0-1023");

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -292,12 +292,11 @@ impl Accessor for Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<ObjectReader> {
         let resp = self.azblob_get_blob(path, args.range()).await?;
 
-        let meta = Self::azblob_parse_object_meta(Operation::Read, path, resp.headers())?;
-
         let status = resp.status();
 
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
+                let meta = Self::azblob_parse_object_meta(Operation::Read, path, resp.headers())?;
                 Ok(ObjectReader::new(resp.into_body().reader()).with_meta(meta))
             }
             _ => {

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -25,7 +25,6 @@ use async_trait::async_trait;
 use http::header::HeaderName;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
-use http::HeaderMap;
 use http::Request;
 use http::Response;
 use http::StatusCode;
@@ -37,18 +36,12 @@ use super::error::parse_error;
 use crate::accessor::AccessorCapability;
 use crate::accessor::AccessorMetadata;
 use crate::error::new_other_backend_error;
-use crate::error::new_other_object_error;
 use crate::http_util::new_request_build_error;
 use crate::http_util::new_request_send_error;
 use crate::http_util::new_request_sign_error;
 use crate::http_util::new_response_consume_error;
-use crate::http_util::parse_content_length;
-use crate::http_util::parse_content_md5;
-use crate::http_util::parse_content_range;
-use crate::http_util::parse_content_type;
 use crate::http_util::parse_error_response;
-use crate::http_util::parse_etag;
-use crate::http_util::parse_last_modified;
+use crate::http_util::parse_into_object_metadata;
 use crate::http_util::percent_encode_path;
 use crate::http_util::AsyncBody;
 use crate::http_util::HttpClient;
@@ -296,7 +289,7 @@ impl Accessor for Backend {
 
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                let meta = Self::azblob_parse_object_meta(Operation::Read, path, resp.headers())?;
+                let meta = parse_into_object_metadata(Operation::Read, path, resp.headers())?;
                 Ok(ObjectReader::new(resp.into_body().reader()).with_meta(meta))
             }
             _ => {
@@ -354,7 +347,7 @@ impl Accessor for Backend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK => Self::azblob_parse_object_meta(Operation::Stat, path, resp.headers()),
+            StatusCode::OK => parse_into_object_metadata(Operation::Stat, path, resp.headers()),
             StatusCode::NOT_FOUND if path.ends_with('/') => {
                 Ok(ObjectMetadata::new(ObjectMode::DIR))
             }
@@ -544,54 +537,5 @@ impl Backend {
             .send_async(req)
             .await
             .map_err(|e| new_request_send_error(Operation::List, path, e))
-    }
-
-    fn azblob_parse_object_meta(
-        op: Operation,
-        path: &str,
-        headers: &HeaderMap,
-    ) -> Result<ObjectMetadata> {
-        let mode = if path.ends_with('/') {
-            ObjectMode::DIR
-        } else {
-            ObjectMode::FILE
-        };
-        let mut m = ObjectMetadata::new(mode);
-
-        if let Some(v) =
-            parse_content_length(headers).map_err(|e| new_other_object_error(op, path, e))?
-        {
-            m.set_content_length(v);
-        }
-
-        if let Some(v) =
-            parse_content_type(headers).map_err(|e| new_other_object_error(op, path, e))?
-        {
-            m.set_content_type(v);
-        }
-
-        if let Some(v) =
-            parse_content_range(headers).map_err(|e| new_other_object_error(op, path, e))?
-        {
-            m.set_content_range(v);
-        }
-
-        if let Some(v) = parse_etag(headers).map_err(|e| new_other_object_error(op, path, e))? {
-            m.set_etag(v);
-        }
-
-        if let Some(v) =
-            parse_content_md5(headers).map_err(|e| new_other_object_error(op, path, e))?
-        {
-            m.set_content_md5(v);
-        }
-
-        if let Some(v) =
-            parse_last_modified(headers).map_err(|e| new_other_object_error(op, path, e))?
-        {
-            m.set_last_modified(v);
-        }
-
-        Ok(m)
     }
 }

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -555,7 +555,7 @@ impl Backend {
         let mut files = resp
             .into_iter()
             .filter_map(|file| File::from_str(file.as_str()).ok())
-            .filter(|f| f.name() == basename)
+            .filter(|f| f.name() == basename.trim_end_matches('/'))
             .collect::<Vec<File>>();
 
         if files.is_empty() {

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -545,7 +545,9 @@ impl Backend {
 
         let (parent, basename) = (get_parent(path), get_basename(path));
 
-        let resp = ftp_stream.list(Some(parent)).await.map_err(|e| {
+        let pathname = if parent == "/" { None } else { Some(parent) };
+
+        let resp = ftp_stream.list(pathname).await.map_err(|e| {
             new_other_object_error(Operation::Stat, path, anyhow!("list request: {e:?}"))
         })?;
 

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::min;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
@@ -55,6 +56,8 @@ use crate::ops::OpRead;
 use crate::ops::OpStat;
 use crate::ops::OpWrite;
 use crate::ops::Operation;
+use crate::path::get_basename;
+use crate::path::get_parent;
 use crate::Accessor;
 use crate::AccessorMetadata;
 use crate::BytesReader;
@@ -363,51 +366,57 @@ impl Accessor for Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<ObjectReader> {
         let mut ftp_stream = self.ftp_connect(Operation::Read).await?;
 
+        let meta = self.ftp_stat(path).await?;
+
         let br = args.range();
-        if let Some(offset) = br.offset() {
-            ftp_stream
-                .resume_transfer(offset as usize)
-                .await
-                .map_err(|e| {
-                    new_other_object_error(
-                        Operation::Read,
-                        path,
-                        anyhow!("resume transfer request: {e:?}"),
-                    )
-                })?;
-        }
-
-        let result = ftp_stream.retr_as_stream(path).await;
-        match result {
-            Err(FtpError::UnexpectedResponse(Response {
-                status: Status::FileUnavailable,
-                body: e,
-            })) => {
-                return Err(Error::new(ErrorKind::NotFound, e));
+        let (r, size): (BytesReader, _) = match (br.offset(), br.size()) {
+            (Some(offset), Some(size)) => {
+                ftp_stream
+                    .resume_transfer(offset as usize)
+                    .await
+                    .map_err(|e| new_ftp_error(e, Operation::Read, path))?;
+                let ds = ftp_stream
+                    .retr_as_stream(path)
+                    .await
+                    .map_err(|err| new_ftp_error(err, Operation::Read, path))?
+                    .take(size);
+                (Box::new(ds), min(size, meta.size() as u64 - offset))
             }
-            Err(e) => {
-                return Err(new_other_object_error(
-                    Operation::Read,
-                    path,
-                    anyhow!("retr request: {e:?}"),
-                ));
+            (Some(offset), None) => {
+                ftp_stream
+                    .resume_transfer(offset as usize)
+                    .await
+                    .map_err(|e| new_ftp_error(e, Operation::Read, path))?;
+                let ds = ftp_stream
+                    .retr_as_stream(path)
+                    .await
+                    .map_err(|err| new_ftp_error(err, Operation::Read, path))?;
+                (Box::new(ds), meta.size() as u64 - offset)
             }
-            Ok(_) => (),
-        }
-
-        // As we handle all error above, it is save to unwrap without panic.
-        let data_stream = result.unwrap();
-
-        let r: BytesReader = match br.size() {
-            None => Box::new(FtpReader::new(Box::new(data_stream), ftp_stream, path)),
-
-            Some(size) => Box::new(FtpReader::new(
-                Box::new(data_stream.take(size)),
-                ftp_stream,
-                path,
-            )),
+            (None, Some(size)) => {
+                ftp_stream
+                    .resume_transfer((meta.size() as u64 - size) as usize)
+                    .await
+                    .map_err(|e| new_ftp_error(e, Operation::Read, path))?;
+                let ds = ftp_stream
+                    .retr_as_stream(path)
+                    .await
+                    .map_err(|err| new_ftp_error(err, Operation::Read, path))?;
+                (Box::new(ds), size)
+            }
+            (None, None) => {
+                let ds = ftp_stream
+                    .retr_as_stream(path)
+                    .await
+                    .map_err(|err| new_ftp_error(err, Operation::Read, path))?;
+                (Box::new(ds), meta.size() as u64)
+            }
         };
-        Ok(ObjectReader::new(r))
+
+        Ok(
+            ObjectReader::new(Box::new(FtpReader::new(r, ftp_stream, path)))
+                .with_meta(ObjectMetadata::new(ObjectMode::FILE).with_content_length(size)),
+        )
     }
 
     async fn write(&self, path: &str, _: OpWrite, r: BytesReader) -> Result<u64> {
@@ -434,66 +443,25 @@ impl Accessor for Backend {
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<ObjectMetadata> {
-        let mut p = path;
-        let path: String;
-
         // root dir, return default ObjectMetadata with Dir ObjectMode.
-        if p == "/" {
+        if path == "/" {
             return Ok(ObjectMetadata::new(ObjectMode::DIR));
         }
 
-        let mut ftp_stream = self.ftp_connect(Operation::Stat).await?;
+        let file = self.ftp_stat(path).await?;
 
-        // If given path points to a directory, split it into parent path and basename.
-        if p.ends_with('/') {
-            if let Some((basename, parent_path)) =
-                p.split_inclusive('/').collect::<Vec<&str>>().split_last()
-            {
-                path = parent_path.join("");
-                p = &basename[..basename.len() - 1];
-            } else {
-                path = "".to_string();
-            }
+        let mode = if file.is_file() {
+            ObjectMode::FILE
+        } else if file.is_directory() {
+            ObjectMode::DIR
         } else {
-            // otherwise, directly use the path provided by arg.
-            path = p.to_string();
-        }
-
-        let resp = ftp_stream.list(Some(&path)).await.map_err(|e| {
-            new_other_object_error(Operation::Stat, &path, anyhow!("list request: {e:?}"))
-        })?;
-
-        // Get stat of file.
-        let files = if p == path {
-            resp.into_iter()
-                .filter_map(|file| File::from_str(file.as_str()).ok())
-                .collect::<Vec<File>>()
-        // Get stat of directory.
-        } else {
-            resp.into_iter()
-                .filter_map(|file| File::from_str(file.as_str()).ok())
-                .filter(|f| f.name() == p)
-                .collect::<Vec<File>>()
+            ObjectMode::Unknown
         };
+        let mut meta = ObjectMetadata::new(mode);
+        meta.set_content_length(file.size() as u64);
+        meta.set_last_modified(OffsetDateTime::from(file.modified()));
 
-        if files.is_empty() {
-            Err(Error::new(ErrorKind::NotFound, "Not Found"))
-        } else {
-            let file = files.get(0).unwrap();
-
-            let mode = if file.is_file() {
-                ObjectMode::FILE
-            } else if file.is_directory() {
-                ObjectMode::DIR
-            } else {
-                ObjectMode::Unknown
-            };
-            let mut meta = ObjectMetadata::new(mode);
-            meta.set_content_length(file.size() as u64);
-            meta.set_last_modified(OffsetDateTime::from(file.modified()));
-
-            Ok(meta)
-        }
+        Ok(meta)
     }
 
     async fn delete(&self, path: &str, _: OpDelete) -> Result<()> {
@@ -570,6 +538,32 @@ impl Backend {
                 ObjectError::new(op, "", anyhow!("connection request: timeout")),
             ),
         })
+    }
+
+    async fn ftp_stat(&self, path: &str) -> Result<File> {
+        let mut ftp_stream = self.ftp_connect(Operation::Stat).await?;
+
+        let (parent, basename) = (get_parent(path), get_basename(path));
+
+        let resp = ftp_stream.list(Some(parent)).await.map_err(|e| {
+            new_other_object_error(Operation::Stat, path, anyhow!("list request: {e:?}"))
+        })?;
+
+        // Get stat of file.
+        let mut files = resp
+            .into_iter()
+            .filter_map(|file| File::from_str(file.as_str()).ok())
+            .filter(|f| f.name() == basename)
+            .collect::<Vec<File>>();
+
+        if files.is_empty() {
+            Err(Error::new(
+                ErrorKind::NotFound,
+                ObjectError::new(Operation::Stat, path, anyhow!("file not found")),
+            ))
+        } else {
+            Ok(files.remove(0))
+        }
     }
 }
 

--- a/src/services/ftp/err.rs
+++ b/src/services/ftp/err.rs
@@ -39,6 +39,12 @@ pub fn new_ftp_error(e: FtpError, op: Operation, path: &str) -> Error {
                 ObjectError::new(op, path, anyhow!("ftp error: {e:?}")),
             )
         }
+        FtpError::UnexpectedResponse(ref resp) if resp.status == Status::FileUnavailable => {
+            Error::new(
+                ErrorKind::NotFound,
+                ObjectError::new(op, path, anyhow!("file not found: {e:?}")),
+            )
+        }
         // Allow retry bad response.
         FtpError::BadResponse => Error::new(
             ErrorKind::Interrupted,

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -274,9 +274,8 @@ impl Accessor for Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<ObjectReader> {
         let resp = self.gcs_get_object(path, args.range()).await?;
 
-        let meta = Self::gcs_parse_object_meta(Operation::Read, path, resp.headers())?;
-
         if resp.status().is_success() {
+            let meta = Self::gcs_parse_object_meta(Operation::Read, path, resp.headers())?;
             Ok(ObjectReader::new(resp.into_body().reader()).with_meta(meta))
         } else {
             let er = parse_error_response(resp).await?;

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -23,6 +23,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
+use http::HeaderMap;
 use http::Request;
 use http::Response;
 use http::StatusCode;
@@ -43,7 +44,11 @@ use crate::http_util::new_request_build_error;
 use crate::http_util::new_request_send_error;
 use crate::http_util::new_request_sign_error;
 use crate::http_util::new_response_consume_error;
+use crate::http_util::parse_content_length;
+use crate::http_util::parse_content_range;
+use crate::http_util::parse_content_type;
 use crate::http_util::parse_error_response;
+use crate::http_util::parse_etag;
 use crate::http_util::AsyncBody;
 use crate::http_util::HttpClient;
 use crate::http_util::IncomingAsyncBody;
@@ -269,8 +274,10 @@ impl Accessor for Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<ObjectReader> {
         let resp = self.gcs_get_object(path, args.range()).await?;
 
+        let meta = Self::gcs_parse_object_meta(Operation::Read, path, resp.headers())?;
+
         if resp.status().is_success() {
-            Ok(ObjectReader::new(resp.into_body().reader()))
+            Ok(ObjectReader::new(resp.into_body().reader()).with_meta(meta))
         } else {
             let er = parse_error_response(resp).await?;
             let e = parse_error(Operation::Read, path, er);
@@ -552,6 +559,66 @@ impl Backend {
             .send_async(req)
             .await
             .map_err(|e| new_request_send_error(Operation::List, path, e))
+    }
+
+    /// Parse object.get with `alt=media`'s header into object metadata.
+    ///
+    /// ```shell
+    /// < HTTP/2 206
+    /// < x-guploader-uploadid: ADPycdugij87Au0-O1vTSR55BHYVUubB9RA0PY26ocja-Y6Lc4qDqKvhIG69KYUeCPPnogF7YBmjpQExFHQ9hkR5ne5qdg
+    /// < content-range: bytes 1-1336122/1336123
+    /// < etag: CKL9i/fIsvsCEAE=
+    /// < content-type: image/png
+    /// < x-goog-stored-content-encoding: identity
+    /// < x-goog-stored-content-length: 1336123
+    /// < x-goog-generation: 1668597191736994
+    /// < x-goog-metageneration: 1
+    // < x-goog-storage-class: STANDARD
+    /// < pragma: no-cache
+    /// < expires: Mon, 01 Jan 1990 00:00:00 GMT
+    /// < cache-control: no-cache, no-store, max-age=0, must-revalidate
+    /// < date: Wed, 16 Nov 2022 11:23:15 GMT
+    /// < vary: Origin
+    /// < vary: X-Origin
+    /// < content-length: 1336122
+    /// < server: UploadServer
+    /// < alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+    /// ```
+    fn gcs_parse_object_meta(
+        op: Operation,
+        path: &str,
+        headers: &HeaderMap,
+    ) -> Result<ObjectMetadata> {
+        let mode = if path.ends_with('/') {
+            ObjectMode::DIR
+        } else {
+            ObjectMode::FILE
+        };
+        let mut m = ObjectMetadata::new(mode);
+
+        if let Some(v) =
+            parse_content_length(headers).map_err(|e| new_other_object_error(op, path, e))?
+        {
+            m.set_content_length(v);
+        }
+
+        if let Some(v) =
+            parse_content_type(headers).map_err(|e| new_other_object_error(op, path, e))?
+        {
+            m.set_content_type(v);
+        }
+
+        if let Some(v) =
+            parse_content_range(headers).map_err(|e| new_other_object_error(op, path, e))?
+        {
+            m.set_content_range(v);
+        }
+
+        if let Some(v) = parse_etag(headers).map_err(|e| new_other_object_error(op, path, e))? {
+            m.set_etag(v);
+        }
+
+        Ok(m)
     }
 }
 

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -245,7 +245,8 @@ impl Accessor for Backend {
                 (Box::new(f), meta.len() - offset)
             }
             (None, Some(size)) => {
-                f.seek(SeekFrom::End(-(size as i64)))
+                // hdfs doesn't support seed from end.
+                f.seek(SeekFrom::Start(meta.len() - size))
                     .map_err(|e| parse_io_error(e, Operation::Read, path))?;
                 (Box::new(f), size)
             }

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -48,6 +48,7 @@ use crate::http_util::parse_content_length;
 use crate::http_util::parse_content_type;
 use crate::http_util::parse_error_response;
 use crate::http_util::parse_etag;
+use crate::http_util::parse_into_object_metadata;
 use crate::http_util::percent_encode_path;
 use crate::http_util::AsyncBody;
 use crate::http_util::HttpClient;
@@ -193,7 +194,8 @@ impl Accessor for Backend {
 
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok(ObjectReader::new(resp.into_body().reader()))
+                let meta = parse_into_object_metadata(Operation::Read, path, resp.headers())?;
+                Ok(ObjectReader::new(resp.into_body().reader()).with_meta(meta))
             }
             _ => {
                 let er = parse_error_response(resp).await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Make ObjectReader content_length returned for all services

- fix https://github.com/datafuselabs/opendal/issues/952
- fix https://github.com/datafuselabs/opendal/issues/948
- fix https://github.com/datafuselabs/opendal/issues/947
