### PR TITLE
build: Make opendal buildable on 1.60

### DIFF
--- a/src/layers/content_cache.rs
+++ b/src/layers/content_cache.rs
@@ -17,12 +17,12 @@ use std::io::ErrorKind;
 use std::io::Result;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use async_trait::async_trait;
 use futures::future::BoxFuture;
+use futures::ready;
 use futures::AsyncRead;
 use futures::FutureExt;
 

--- a/src/layers/content_cache.rs
+++ b/src/layers/content_cache.rs
@@ -65,6 +65,7 @@ use crate::ObjectStreamer;
 ///
 /// ```
 /// use std::sync::Arc;
+///
 /// use anyhow::Result;
 /// use opendal::layers::ContentCacheLayer;
 /// use opendal::layers::ContentCacheStrategy;

--- a/src/object/stream.rs
+++ b/src/object/stream.rs
@@ -15,7 +15,6 @@
 use std::io::Result;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 use std::vec::IntoIter;
@@ -23,6 +22,7 @@ use std::vec::IntoIter;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use futures::lock::Mutex;
+use futures::ready;
 use futures::Future;
 use futures::Stream;
 use pin_project::pin_project;


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

build: Make opendal buildable on 1.60

We don't have a strong declear on the msrv about opendal, but we can make our users lives a bit easier.

fix https://github.com/datafuselabs/opendal/issues/967
