### PR TITLE
feat: improve temp file organization when enable atomic write in fs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1.20", features = ["fs"] }
 tracing = { version = "0.1", optional = true }
 ureq = { version = "2", default-features = false }
+uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 cfg-if = "1"
@@ -164,5 +165,4 @@ size = "0.4"
 tokio = { version = "1.20", features = ["fs", "macros", "rt-multi-thread"] }
 tracing-opentelemetry = "0.17"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1", features = ["serde", "v4"] }
 wiremock = "0.5"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Under the current implementation, it will create many unnecessary temp folders when enabling atomic write in fs service.

So in this PR, I removed these temp folders, all temp files will be created in `atomic_write_path` folder but using a temp file name.
