### PR TITLE
feat(presign): support presign head method for s3 and oss

### DIFF
--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -25,7 +25,6 @@ use time::OffsetDateTime;
 
 use super::BlockingObjectLister;
 use super::ObjectLister;
-use crate::ops::OpHead;
 use crate::raw::*;
 use crate::*;
 
@@ -1476,7 +1475,7 @@ impl Object {
             },
         }
     }
-    /// Presign an operation for read.
+    /// Presign an operation for stat(head).
     ///
     /// # Example
     ///
@@ -1491,7 +1490,7 @@ impl Object {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     /// #    let op = Operator::from_env(Scheme::Memory)?;
-    ///     let signed_req = op.object("test").presign_head(Duration::hours(1))?;
+    ///     let signed_req = op.object("test").presign_stat(Duration::hours(1))?;
     ///     let req = http::Request::builder()
     ///         .method(signed_req.method())
     ///         .uri(signed_req.uri())
@@ -1500,8 +1499,8 @@ impl Object {
     /// #    Ok(())
     /// # }
     /// ```
-    pub fn presign_head(&self, expire: Duration) -> Result<PresignedRequest> {
-        let op = OpPresign::new(OpHead::new(), expire);
+    pub fn presign_stat(&self, expire: Duration) -> Result<PresignedRequest> {
+        let op = OpPresign::new(OpStat::new(), expire);
 
         let rp = self.acc.presign(self.path(), op)?;
         Ok(rp.into_presigned_request())

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -25,9 +25,9 @@ use time::OffsetDateTime;
 
 use super::BlockingObjectLister;
 use super::ObjectLister;
+use crate::ops::OpHead;
 use crate::raw::*;
 use crate::*;
-use crate::ops::OpHead;
 
 /// Object is the handler for all object related operations.
 ///

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -27,6 +27,7 @@ use super::BlockingObjectLister;
 use super::ObjectLister;
 use crate::raw::*;
 use crate::*;
+use crate::ops::OpHead;
 
 /// Object is the handler for all object related operations.
 ///
@@ -1474,6 +1475,36 @@ impl Object {
                 _ => Err(err),
             },
         }
+    }
+    /// Presign an operation for read.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use futures::io;
+    /// use opendal::services::memory;
+    /// use opendal::Operator;
+    /// use time::Duration;
+    /// # use opendal::Scheme;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    /// #    let op = Operator::from_env(Scheme::Memory)?;
+    ///     let signed_req = op.object("test").presign_head(Duration::hours(1))?;
+    ///     let req = http::Request::builder()
+    ///         .method(signed_req.method())
+    ///         .uri(signed_req.uri())
+    ///         .body(())?;
+    ///
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn presign_head(&self, expire: Duration) -> Result<PresignedRequest> {
+        let op = OpPresign::new(OpHead::new(), expire);
+
+        let rp = self.acc.presign(self.path(), op)?;
+        Ok(rp.into_presigned_request())
     }
 
     /// Presign an operation for read.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -186,12 +186,20 @@ impl OpPresign {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum PresignOperation {
+    /// Presign a head operation.
+    Head(OpHead),
     /// Presign a read operation.
     Read(OpRead),
     /// Presign a write operation.
     Write(OpWrite),
     /// Presign a write multipart operation.
     WriteMultipart(OpWriteMultipart),
+}
+
+impl From<OpHead> for PresignOperation {
+    fn from(op: OpHead) -> Self {
+        Self::Head(op)
+    }
 }
 
 impl From<OpRead> for PresignOperation {
@@ -209,6 +217,16 @@ impl From<OpWrite> for PresignOperation {
 impl From<OpWriteMultipart> for PresignOperation {
     fn from(v: OpWriteMultipart) -> Self {
         Self::WriteMultipart(v)
+    }
+}
+
+/// Args for `head` operation.
+#[derive(Debug, Clone, Default)]
+pub struct OpHead {}
+
+impl OpHead {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -186,8 +186,8 @@ impl OpPresign {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum PresignOperation {
-    /// Presign a head operation.
-    Head(OpHead),
+    /// Presign a stat(head) operation.
+    Stat(OpStat),
     /// Presign a read operation.
     Read(OpRead),
     /// Presign a write operation.
@@ -196,9 +196,9 @@ pub enum PresignOperation {
     WriteMultipart(OpWriteMultipart),
 }
 
-impl From<OpHead> for PresignOperation {
-    fn from(op: OpHead) -> Self {
-        Self::Head(op)
+impl From<OpStat> for PresignOperation {
+    fn from(op: OpStat) -> Self {
+        Self::Stat(op)
     }
 }
 
@@ -217,16 +217,6 @@ impl From<OpWrite> for PresignOperation {
 impl From<OpWriteMultipart> for PresignOperation {
     fn from(v: OpWriteMultipart) -> Self {
         Self::WriteMultipart(v)
-    }
-}
-
-/// Args for `head` operation.
-#[derive(Debug, Clone, Default)]
-pub struct OpHead {}
-
-impl OpHead {
-    pub fn new() -> Self {
-        Self::default()
     }
 }
 

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -358,6 +358,7 @@ impl Accessor for Backend {
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
+            PresignOperation::Head(_) => self.oss_head_object_request(path)?,
             PresignOperation::Read(v) => self.oss_get_object_request(path, v.range())?,
             PresignOperation::Write(_) => {
                 self.oss_put_object_request(path, None, None, AsyncBody::Empty)?

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -358,7 +358,7 @@ impl Accessor for Backend {
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
-            PresignOperation::Head(_) => self.oss_head_object_request(path)?,
+            PresignOperation::Stat(_) => self.oss_head_object_request(path)?,
             PresignOperation::Read(v) => self.oss_get_object_request(path, v.range())?,
             PresignOperation::Write(_) => {
                 self.oss_put_object_request(path, None, None, AsyncBody::Empty)?

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -882,7 +882,7 @@ impl Accessor for Backend {
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
-            PresignOperation::Head(_) => self.s3_head_object_request(path)?,
+            PresignOperation::Stat(_) => self.s3_head_object_request(path)?,
             PresignOperation::Read(v) => self.s3_get_object_request(path, v.range())?,
             PresignOperation::Write(_) => {
                 self.s3_put_object_request(path, None, None, AsyncBody::Empty)?

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -1024,7 +1024,9 @@ impl Backend {
 
         req = self.insert_sse_headers(req, false);
 
-        let req = req.body(AsyncBody::Empty).map_err(new_request_build_error)?;
+        let req = req
+            .body(AsyncBody::Empty)
+            .map_err(new_request_build_error)?;
 
         Ok(req)
     }

--- a/tests/behavior/presign.rs
+++ b/tests/behavior/presign.rs
@@ -122,7 +122,7 @@ pub async fn test_presign_head(op: Operator) -> Result<()> {
         .write(content.clone())
         .await
         .expect("write must succeed");
-    let signed_req = op.object(&path).presign_head(Duration::hours(1))?;
+    let signed_req = op.object(&path).presign_stat(Duration::hours(1))?;
     debug!("Generated request: {signed_req:?}");
     let client = reqwest::Client::new();
     let mut req = client.request(

--- a/tests/behavior/presign.rs
+++ b/tests/behavior/presign.rs
@@ -133,14 +133,10 @@ pub async fn test_presign_head(op: Operator) -> Result<()> {
         req = req.header(k, v);
     }
     let resp = req.send().await.expect("send request must succeed");
+    assert_eq!(resp.status(), http::StatusCode::OK, "status ok",);
 
-    let bs = resp.bytes().await.expect("read response must succeed");
-    assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(resp.content_length(), Some(size as u64), "content length",);
+
     op.object(&path)
         .delete()
         .await


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This pull request adds support for generating pre-signed URLs for the HEAD method on Amazon S3 and Aliyun OSS (Object Storage Service) objects. 

This allows clients to perform presign head operation on s3 or oss, as an example:
```rust
use anyhow::Result;
use futures::io;
use opendal::services::memory;
use opendal::Operator;
use time::Duration;
# use opendal::Scheme;

#[tokio::main]
async fn main() -> Result<()> {
    let op = Operator::from_env(Scheme::Memory)?;
    let signed_req = op.object("test").presign_stat(Duration::hours(1))?;
    let req = http::Request::builder()
        .method(signed_req.method())
        .uri(signed_logreq.uri())
        .body(())?;

    Ok(())
}

```


This pull request has passed all the necessary checks and tests, including static analysis with cargo check, linting with cargo clippy, unit and integration tests with cargo test, and benchmarking with cargo bench. 