### PR TITLE
fix: read a large range without error and add test

### DIFF
--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -450,15 +450,11 @@ impl Object {
         }
 
         let br = BytesRange::from(range);
-        let (_, mut s) = self
+        let (rp, mut s) = self
             .acc
             .blocking_read(self.path(), OpRead::new().with_range(br))?;
 
-        let mut buffer = if let Some(range_size) = br.size() {
-            Vec::with_capacity(range_size as usize)
-        } else {
-            Vec::with_capacity(4 * 1024 * 1024)
-        };
+        let mut buffer = Vec::with_capacity(rp.into_metadata().content_length() as usize);
 
         std::io::copy(&mut s, &mut buffer).map_err(|err| {
             Error::new(ErrorKind::Unexpected, "blocking range read failed")

--- a/tests/behavior/blocking_write.rs
+++ b/tests/behavior/blocking_write.rs
@@ -79,6 +79,7 @@ macro_rules! behavior_blocking_write_tests {
                 test_stat_not_exist,
                 test_read_full,
                 test_read_range,
+                test_read_large_range,
                 test_read_not_exist,
                 test_delete,
             );
@@ -346,6 +347,23 @@ pub fn test_read_range(op: Operator) -> Result<()> {
         ),
         "read content"
     );
+
+    op.object(&path)
+        .blocking_delete()
+        .expect("delete must succeed");
+    Ok(())
+}
+
+/// Read large range content should match.
+pub fn test_read_large_range(op: Operator) -> Result<()> {
+    let path = uuid::Uuid::new_v4().to_string();
+    debug!("Generate a random file: {}", &path);
+    let (content, size) = gen_bytes();
+    let (offset, _) = gen_offset_length(size as usize);
+
+    op.object(&path)
+        .blocking_write(content.clone())
+        .expect("write must succeed");
 
     let bs = op.object(&path).blocking_range_read(offset..u64::MAX)?;
     assert_eq!(

--- a/tests/behavior/blocking_write.rs
+++ b/tests/behavior/blocking_write.rs
@@ -365,7 +365,9 @@ pub fn test_read_large_range(op: Operator) -> Result<()> {
         .blocking_write(content.clone())
         .expect("write must succeed");
 
-    let bs = op.object(&path).blocking_range_read(offset..u64::MAX)?;
+    let bs = op
+        .object(&path)
+        .blocking_range_read(offset..u32::MAX as u64)?;
     assert_eq!(
         bs.len() as u64,
         size as u64 - offset,

--- a/tests/behavior/blocking_write.rs
+++ b/tests/behavior/blocking_write.rs
@@ -347,6 +347,18 @@ pub fn test_read_range(op: Operator) -> Result<()> {
         "read content"
     );
 
+    let bs = op.object(&path).blocking_range_read(offset..u64::MAX)?;
+    assert_eq!(
+        bs.len() as u64,
+        size as u64 - offset,
+        "read size with large range"
+    );
+    assert_eq!(
+        format!("{:x}", Sha256::digest(&bs)),
+        format!("{:x}", Sha256::digest(&content[offset as usize..])),
+        "read content with large range"
+    );
+
     op.object(&path)
         .blocking_delete()
         .expect("delete must succeed");

--- a/tests/behavior/write.rs
+++ b/tests/behavior/write.rs
@@ -421,7 +421,7 @@ pub async fn test_read_large_range(op: Operator) -> Result<()> {
         .await
         .expect("write must succeed");
 
-    let bs = op.object(&path).range_read(offset..u64::MAX).await?;
+    let bs = op.object(&path).range_read(offset..u32::MAX as u64).await?;
     assert_eq!(
         bs.len() as u64,
         size as u64 - offset,

--- a/tests/behavior/write.rs
+++ b/tests/behavior/write.rs
@@ -401,6 +401,18 @@ pub async fn test_read_range(op: Operator) -> Result<()> {
         "read content"
     );
 
+    let bs = op.object(&path).range_read(offset..u64::MAX).await?;
+    assert_eq!(
+        bs.len() as u64,
+        size as u64 - offset,
+        "read size with large range"
+    );
+    assert_eq!(
+        format!("{:x}", Sha256::digest(&bs)),
+        format!("{:x}", Sha256::digest(&content[offset as usize..])),
+        "read content with large range"
+    );
+
     op.object(&path)
         .delete()
         .await

--- a/tests/behavior/write.rs
+++ b/tests/behavior/write.rs
@@ -402,18 +402,6 @@ pub async fn test_read_range(op: Operator) -> Result<()> {
         "read content"
     );
 
-    let bs = op.object(&path).range_read(offset..u64::MAX).await?;
-    assert_eq!(
-        bs.len() as u64,
-        size as u64 - offset,
-        "read size with large range"
-    );
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content[offset as usize..])),
-        "read content with large range"
-    );
-
     op.object(&path)
         .delete()
         .await


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
Close #943 fix error if block range read with a large range and add test for it.