### PR TITLE
improve blocking read use read_to_end

### DIFF
--- a/benches/ops/read.rs
+++ b/benches/ops/read.rs
@@ -55,7 +55,7 @@ fn bench_read_full(c: &mut Criterion, op: Operator) {
             b.to_async(&*TOKIO).iter(|| async {
                 let r = op
                     .object(path)
-                    .range_reader(..=size.bytes() as u64)
+                    .range_reader(0..=size.bytes() as u64)
                     .await
                     .unwrap();
                 io::copy(r, &mut io::sink()).await.unwrap();

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -455,8 +455,7 @@ impl Object {
             .blocking_read(self.path(), OpRead::new().with_range(br))?;
 
         let mut buffer = Vec::with_capacity(rp.into_metadata().content_length() as usize);
-
-        std::io::copy(&mut s, &mut buffer).map_err(|err| {
+        s.read_to_end(&mut buffer).map_err(|err| {
             Error::new(ErrorKind::Unexpected, "blocking range read failed")
                 .with_operation("Object::blocking_range_read")
                 .with_context("service", self.accessor().metadata().scheme().into_static())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

1. fix a bug in bench
2. use `read_to_end` instead of `std::io::copy`
