### PR TITLE
feat: Split bytes reader into input and output

### DIFF
--- a/src/layers/cache/accessor.rs
+++ b/src/layers/cache/accessor.rs
@@ -54,7 +54,7 @@ impl Accessor for CacheAccessor {
             .await
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         self.policy
             .on_read(self.inner.clone(), self.cache.clone(), path, args)
             .await

--- a/src/layers/cache/policy.rs
+++ b/src/layers/cache/policy.rs
@@ -45,7 +45,7 @@ pub trait CachePolicy: Send + Sync + Debug + 'static {
         cache: Arc<dyn Accessor>,
         path: &str,
         args: OpRead,
-    ) -> CacheResult<(RpRead, BytesReader)> {
+    ) -> CacheResult<(RpRead, OutputBytesReader)> {
         let _ = cache;
 
         let path = path.to_string();
@@ -99,7 +99,7 @@ impl<T: CachePolicy> CachePolicy for Arc<T> {
         cache: Arc<dyn Accessor>,
         path: &str,
         args: OpRead,
-    ) -> CacheResult<(RpRead, BytesReader)> {
+    ) -> CacheResult<(RpRead, OutputBytesReader)> {
         self.as_ref().on_read(inner, cache, path, args)
     }
 

--- a/src/layers/concurrent_limit.rs
+++ b/src/layers/concurrent_limit.rs
@@ -88,7 +88,7 @@ impl Accessor for ConcurrentLimitAccessor {
         self.inner.create(path, args).await
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let permit = self
             .semaphore
             .clone()
@@ -99,7 +99,7 @@ impl Accessor for ConcurrentLimitAccessor {
         self.inner.read(path, args).await.map(|(rp, r)| {
             (
                 rp,
-                Box::new(ConcurrentLimitReader::new(r, permit)) as BytesReader,
+                Box::new(ConcurrentLimitReader::new(r, permit)) as OutputBytesReader,
             )
         })
     }
@@ -279,14 +279,14 @@ impl Accessor for ConcurrentLimitAccessor {
 }
 
 struct ConcurrentLimitReader {
-    inner: BytesReader,
+    inner: OutputBytesReader,
 
     // Hold on this permit until this reader has been dropped.
     _permit: OwnedSemaphorePermit,
 }
 
 impl ConcurrentLimitReader {
-    fn new(inner: BytesReader, permit: OwnedSemaphorePermit) -> Self {
+    fn new(inner: OutputBytesReader, permit: OwnedSemaphorePermit) -> Self {
         Self {
             inner,
             _permit: permit,

--- a/src/layers/logging.rs
+++ b/src/layers/logging.rs
@@ -203,7 +203,7 @@ impl Accessor for LoggingAccessor {
             })
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} path={} range={} -> started",
@@ -234,7 +234,7 @@ impl Accessor for LoggingAccessor {
                         args.range().size(),
                         r,
                         self.failure_level,
-                    )) as BytesReader,
+                    )) as OutputBytesReader,
                 )
             })
             .map_err(|err| {
@@ -982,7 +982,7 @@ impl Accessor for LoggingAccessor {
 }
 
 /// `LoggingReader` is a wrapper of `BytesReader`, with logging functionality.
-struct LoggingReader {
+struct LoggingReader<R> {
     scheme: Scheme,
     path: String,
     op: Operation,
@@ -991,16 +991,16 @@ struct LoggingReader {
     has_read: u64,
     failure_level: Option<Level>,
 
-    inner: BytesReader,
+    inner: R,
 }
 
-impl LoggingReader {
+impl<R> LoggingReader<R> {
     fn new(
         scheme: Scheme,
         op: Operation,
         path: &str,
         size: Option<u64>,
-        reader: BytesReader,
+        reader: R,
         failure_level: Option<Level>,
     ) -> Self {
         Self {
@@ -1017,7 +1017,7 @@ impl LoggingReader {
     }
 }
 
-impl Drop for LoggingReader {
+impl<R> Drop for LoggingReader<R> {
     fn drop(&mut self) {
         if let Some(size) = self.size {
             if size == self.has_read {
@@ -1045,13 +1045,13 @@ impl Drop for LoggingReader {
     }
 }
 
-impl AsyncRead for LoggingReader {
+impl<R: AsyncRead + Unpin + Send> AsyncRead for LoggingReader<R> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        match Pin::new(&mut (*self.inner)).poll_read(cx, buf) {
+        match Pin::new(&mut self.inner).poll_read(cx, buf) {
             Poll::Ready(res) => match res {
                 Ok(n) => {
                     self.has_read += n as u64;

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -303,7 +303,11 @@ where
         Err(e.unwrap())
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         let retry = self.backoff.clone();
 
         let mut e = None;

--- a/src/layers/subdir.rs
+++ b/src/layers/subdir.rs
@@ -95,7 +95,7 @@ impl Accessor for SubdirAccessor {
         self.inner.create(&path, args).await
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let path = self.prepend_subdir(path);
 
         self.inner.read(&path, args).await

--- a/src/layers/subdir.rs
+++ b/src/layers/subdir.rs
@@ -179,7 +179,11 @@ impl Accessor for SubdirAccessor {
         self.inner.blocking_create(&path, args)
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         let path = self.prepend_subdir(path);
 
         self.inner.blocking_read(&path, args)

--- a/src/object/reader.rs
+++ b/src/object/reader.rs
@@ -27,29 +27,29 @@ use crate::ObjectMetadata;
 /// Users could fetch part of metadata that carried by read response.
 pub struct ObjectReader {
     meta: ObjectMetadata,
-    inner: BytesReader,
+    inner: OutputBytesReader,
 }
 
 impl ObjectReader {
     /// Create a new object reader.
-    pub fn new(meta: ObjectMetadata, inner: BytesReader) -> Self {
+    pub fn new(meta: ObjectMetadata, inner: OutputBytesReader) -> Self {
         ObjectReader { meta, inner }
     }
 
     /// Replace the bytes reader with new one.
-    pub fn with_reader(mut self, inner: BytesReader) -> Self {
+    pub fn with_reader(mut self, inner: OutputBytesReader) -> Self {
         self.inner = inner;
         self
     }
 
     /// Replace the bytes reader with new one.
-    pub fn map_reader(mut self, f: impl FnOnce(BytesReader) -> BytesReader) -> Self {
+    pub fn map_reader(mut self, f: impl FnOnce(OutputBytesReader) -> OutputBytesReader) -> Self {
         self.inner = f(self.inner);
         self
     }
 
     /// Convert into a bytes reader to consume the reader.
-    pub fn into_reader(self) -> BytesReader {
+    pub fn into_reader(self) -> OutputBytesReader {
         self.inner
     }
 
@@ -61,7 +61,7 @@ impl ObjectReader {
     ///
     /// The [`ObjectMetadata`] is **different** from the whole object's
     /// metadata. It just described the corresbonding reader's metadata.
-    pub fn into_parts(self) -> (ObjectMetadata, BytesReader) {
+    pub fn into_parts(self) -> (ObjectMetadata, OutputBytesReader) {
         (self.meta, self.inner)
     }
 

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -314,7 +314,11 @@ pub trait Accessor: Send + Sync + Debug + 'static {
     /// # Behavior
     ///
     /// - Require capability: `Blocking`
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         match self.inner() {
             Some(inner) => inner.blocking_read(path, args),
             None => Err(Error::new(
@@ -474,7 +478,11 @@ impl<T: Accessor> Accessor for Arc<T> {
     fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.as_ref().blocking_create(path, args)
     }
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         self.as_ref().blocking_read(path, args)
     }
     fn blocking_write(&self, path: &str, args: OpWrite, r: BlockingBytesReader) -> Result<RpWrite> {

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -110,7 +110,7 @@ pub trait Accessor: Send + Sync + Debug + 'static {
     ///
     /// - Input path MUST be file path, DON'T NEED to check object mode.
     /// - The returning contnet length may be smaller than the range specifed.
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         match self.inner() {
             Some(inner) => inner.read(path, args).await,
             None => Err(Error::new(
@@ -418,7 +418,7 @@ impl<T: Accessor> Accessor for Arc<T> {
     async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.as_ref().create(path, args).await
     }
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         self.as_ref().read(path, args).await
     }
     async fn write(&self, path: &str, args: OpWrite, r: BytesReader) -> Result<RpWrite> {

--- a/src/raw/adapters/kv/backend.rs
+++ b/src/raw/adapters/kv/backend.rs
@@ -91,7 +91,11 @@ where
         Ok((RpRead::new(length as u64), Box::new(Cursor::new(bs))))
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         let bs = match self.kv.blocking_get(path)? {
             Some(bs) => bs,
             None => {

--- a/src/raw/adapters/kv/backend.rs
+++ b/src/raw/adapters/kv/backend.rs
@@ -74,7 +74,7 @@ where
         Ok(RpCreate::default())
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let bs = match self.kv.get(path).await? {
             Some(bs) => bs,
             None => {

--- a/src/raw/http_util/body.rs
+++ b/src/raw/http_util/body.rs
@@ -112,11 +112,11 @@ impl From<AsyncBody> for reqwest::Body {
 /// # Notes
 ///
 /// Client SHOULD NEVER construct this body.
-pub struct IncomingAsyncBody(BytesReader);
+pub struct IncomingAsyncBody(OutputBytesReader);
 
 impl IncomingAsyncBody {
     /// Construct a new incoming async body
-    pub fn new(r: BytesReader) -> Self {
+    pub fn new(r: OutputBytesReader) -> Self {
         Self(r)
     }
 
@@ -147,7 +147,7 @@ impl IncomingAsyncBody {
     }
 
     /// Consume the response to build a reader.
-    pub fn reader(self) -> BytesReader {
+    pub fn reader(self) -> OutputBytesReader {
         self.0
     }
 }

--- a/src/raw/io.rs
+++ b/src/raw/io.rs
@@ -31,12 +31,12 @@ impl<T> BytesRead for T where T: AsyncRead + Unpin + Send {}
 /// BytesReader is a boxed dyn [`BytesRead`].
 pub type BytesReader = Box<dyn BytesRead>;
 
-/// BytesHandle represents a handle of bytes which can be read and seek.
-pub trait BytesHandle: AsyncRead + AsyncSeek + Unpin + Send {}
-impl<T> BytesHandle for T where T: AsyncRead + AsyncSeek + Unpin + Send {}
+/// OutputBytesRead is the output version of bytes returned by OpenDAL.
+pub trait OutputBytesRead: BytesRead + Sync {}
+impl<T> OutputBytesRead for T where T: BytesRead + Sync {}
 
-/// BytesHandler is a boxed dyn [`BytesHandle`].
-pub type BytesHandler = Box<dyn BytesHandle>;
+/// OutputBytesReader is a boxed dyn [`OutputBytesRead`].
+pub type OutputBytesReader = Box<dyn OutputBytesRead>;
 
 /// BlockingBytesRead represents a blocking reader of bytes.
 pub trait BlockingBytesRead: Read + Send + Sync {}
@@ -44,6 +44,13 @@ impl<T> BlockingBytesRead for T where T: Read + Send + Sync {}
 
 /// BlockingBytesReader is a boxed dyn [`BlockingBytesRead`].
 pub type BlockingBytesReader = Box<dyn BlockingBytesRead>;
+
+/// BytesHandle represents a handle of bytes which can be read and seek.
+pub trait BytesHandle: AsyncRead + AsyncSeek + Unpin + Send {}
+impl<T> BytesHandle for T where T: AsyncRead + AsyncSeek + Unpin + Send {}
+
+/// BytesHandler is a boxed dyn [`BytesHandle`].
+pub type BytesHandler = Box<dyn BytesHandle>;
 
 /// BytesHandle represents a handle of bytes which can be read an seek.
 pub trait BlockingBytesHandle: Read + Seek + Send {}

--- a/src/raw/io.rs
+++ b/src/raw/io.rs
@@ -39,11 +39,19 @@ impl<T> OutputBytesRead for T where T: BytesRead + Sync {}
 pub type OutputBytesReader = Box<dyn OutputBytesRead>;
 
 /// BlockingBytesRead represents a blocking reader of bytes.
-pub trait BlockingBytesRead: Read + Send + Sync {}
-impl<T> BlockingBytesRead for T where T: Read + Send + Sync {}
+pub trait BlockingBytesRead: Read + Send {}
+impl<T> BlockingBytesRead for T where T: Read + Send {}
 
 /// BlockingBytesReader is a boxed dyn [`BlockingBytesRead`].
 pub type BlockingBytesReader = Box<dyn BlockingBytesRead>;
+
+/// BlockingOutputBytesRead is the output version of bytes reader
+/// returned by OpenDAL.
+pub trait BlockingOutputBytesRead: BlockingBytesRead + Sync {}
+impl<T> BlockingOutputBytesRead for T where T: BlockingBytesRead + Sync {}
+
+/// BlockingOutputBytesReader is a boxed dyn [`u`].
+pub type BlockingOutputBytesReader = Box<dyn BlockingOutputBytesRead>;
 
 /// BytesHandle represents a handle of bytes which can be read and seek.
 pub trait BytesHandle: AsyncRead + AsyncSeek + Unpin + Send {}

--- a/src/raw/io_util/seekable_reader.rs
+++ b/src/raw/io_util/seekable_reader.rs
@@ -79,9 +79,9 @@ pub struct SeekableReader {
 
 enum State {
     Idle,
-    Sending(BoxFuture<'static, Result<(RpRead, BytesReader)>>),
+    Sending(BoxFuture<'static, Result<(RpRead, OutputBytesReader)>>),
     Seeking(BoxFuture<'static, Result<RpStat>>),
-    Reading(BytesReader),
+    Reading(OutputBytesReader),
 }
 
 impl SeekableReader {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -39,6 +39,8 @@ pub use io::BytesSink;
 pub use io::BytesStream;
 pub use io::BytesWrite;
 pub use io::BytesWriter;
+pub use io::OutputBytesRead;
+pub use io::OutputBytesReader;
 
 mod path;
 pub use path::build_abs_path;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -32,6 +32,8 @@ mod io;
 pub use io::BlockingBytesHandler;
 pub use io::BlockingBytesRead;
 pub use io::BlockingBytesReader;
+pub use io::BlockingOutputBytesRead;
+pub use io::BlockingOutputBytesReader;
 pub use io::BytesHandler;
 pub use io::BytesRead;
 pub use io::BytesReader;

--- a/src/raw/wrappers/error_context.rs
+++ b/src/raw/wrappers/error_context.rs
@@ -198,7 +198,11 @@ impl<T: Accessor + 'static> Accessor for ErrorContextWrapper<T> {
         })
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         self.inner.blocking_read(path, args).map_err(|err| {
             err.with_operation(Operation::BlockingRead.into_static())
                 .with_context("service", self.meta.scheme())

--- a/src/raw/wrappers/error_context.rs
+++ b/src/raw/wrappers/error_context.rs
@@ -55,7 +55,7 @@ impl<T: Accessor + 'static> Accessor for ErrorContextWrapper<T> {
         })
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let br = args.range();
         self.inner.read(path, args).await.map_err(|err| {
             err.with_operation(Operation::Read.into_static())

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -310,7 +310,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.azblob_get_blob(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/azdfs/backend.rs
+++ b/src/services/azdfs/backend.rs
@@ -243,7 +243,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.azdfs_read(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -513,7 +513,11 @@ impl Accessor for Backend {
         unreachable!()
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         use std::io::Seek;
 
         let p = build_rooted_abs_path(&self.root, path);
@@ -527,7 +531,7 @@ impl Accessor for Backend {
             .map_err(parse_io_error)?;
 
         let br = args.range();
-        let (r, size): (BlockingBytesReader, _) = match (br.offset(), br.size()) {
+        let (r, size): (BlockingOutputBytesReader, _) = match (br.offset(), br.size()) {
             // Read a specific range.
             (Some(offset), Some(size)) => {
                 match offset {
@@ -562,7 +566,7 @@ impl Accessor for Backend {
             (None, None) => (Box::new(f), meta.len()),
         };
 
-        Ok((RpRead::new(size), Box::new(r) as BlockingBytesReader))
+        Ok((RpRead::new(size), Box::new(r) as BlockingOutputBytesReader))
     }
 
     fn blocking_write(

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -281,7 +281,7 @@ impl Accessor for Backend {
         unreachable!()
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let p = build_rooted_abs_path(&self.root, path);
 
         // Validate if input path is a valid file.
@@ -302,7 +302,7 @@ impl Accessor for Backend {
         let mut f = Compat::new(f);
 
         let br = args.range();
-        let (r, size): (BytesReader, _) = match (br.offset(), br.size()) {
+        let (r, size): (OutputBytesReader, _) = match (br.offset(), br.size()) {
             // Read a specific range.
             (Some(offset), Some(size)) => {
                 match offset {
@@ -342,7 +342,7 @@ impl Accessor for Backend {
             (None, None) => (Box::new(f), meta.len()),
         };
 
-        Ok((RpRead::new(size), Box::new(r) as BytesReader))
+        Ok((RpRead::new(size), Box::new(r) as OutputBytesReader))
     }
 
     async fn write(&self, path: &str, _: OpWrite, r: BytesReader) -> Result<RpWrite> {

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -310,13 +310,13 @@ impl Accessor for Backend {
         return Ok(RpCreate::default());
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let mut ftp_stream = self.ftp_connect(Operation::Read).await?;
 
         let meta = self.ftp_stat(path).await?;
 
         let br = args.range();
-        let (r, size): (BytesReader, _) = match (br.offset(), br.size()) {
+        let (r, size): (OutputBytesReader, _) = match (br.offset(), br.size()) {
             (Some(offset), Some(size)) => {
                 ftp_stream.resume_transfer(offset as usize).await?;
                 let ds = ftp_stream.retr_as_stream(path).await?.take(size);
@@ -342,7 +342,7 @@ impl Accessor for Backend {
 
         Ok((
             RpRead::new(size),
-            Box::new(FtpReader::new(r, ftp_stream)) as BytesReader,
+            Box::new(FtpReader::new(r, ftp_stream)) as OutputBytesReader,
         ))
     }
 

--- a/src/services/ftp/util.rs
+++ b/src/services/ftp/util.rs
@@ -30,9 +30,11 @@ use crate::Result;
 
 /// Wrapper for ftp data stream and command stream.
 pub struct FtpReader {
-    reader: BytesReader,
+    reader: OutputBytesReader,
     state: State,
 }
+
+unsafe impl Sync for FtpReader {}
 
 pub enum State {
     Reading(Option<PooledConnection<'static, Manager>>),
@@ -41,7 +43,7 @@ pub enum State {
 
 impl FtpReader {
     /// Create an instance of FtpReader.
-    pub fn new(r: BytesReader, c: PooledConnection<'static, Manager>) -> Self {
+    pub fn new(r: OutputBytesReader, c: PooledConnection<'static, Manager>) -> Self {
         Self {
             reader: r,
             state: State::Reading(Some(c)),

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -302,7 +302,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.gcs_get_object(path, args.range()).await?;
 
         if resp.status().is_success() {

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -369,7 +369,11 @@ impl Accessor for Backend {
         }
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, BlockingBytesReader)> {
+    fn blocking_read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> Result<(RpRead, BlockingOutputBytesReader)> {
         use std::io::Read;
 
         let p = build_rooted_abs_path(&self.root, path);
@@ -386,7 +390,7 @@ impl Accessor for Backend {
 
         let br = args.range();
 
-        let (r, size): (BlockingBytesReader, _) = match (br.offset(), br.size()) {
+        let (r, size): (BlockingOutputBytesReader, _) = match (br.offset(), br.size()) {
             (Some(offset), Some(size)) => {
                 f.seek(SeekFrom::Start(offset)).map_err(parse_io_error)?;
                 (Box::new(f.take(size)), min(size, meta.len() - offset))

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -183,7 +183,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         use futures::AsyncReadExt;
 
         let p = build_rooted_abs_path(&self.root, path);
@@ -200,7 +200,7 @@ impl Accessor for Backend {
 
         let br = args.range();
 
-        let (r, size): (BytesReader, _) = match (br.offset(), br.size()) {
+        let (r, size): (OutputBytesReader, _) = match (br.offset(), br.size()) {
             (Some(offset), Some(size)) => {
                 f.seek(SeekFrom::Start(offset)).map_err(parse_io_error)?;
                 (Box::new(f.take(size)), min(size, meta.len() - offset))

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -139,7 +139,7 @@ impl Accessor for Backend {
         ma
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.http_get(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -149,7 +149,7 @@ impl Accessor for Backend {
         ma
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.ipfs_get(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/ipmfs/backend.rs
+++ b/src/services/ipmfs/backend.rs
@@ -87,7 +87,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.ipmfs_read(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/obs/backend.rs
+++ b/src/services/obs/backend.rs
@@ -258,7 +258,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.obs_get_object(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -281,7 +281,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.oss_get_object(path, args.range()).await?;
 
         let status = resp.status();

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -832,7 +832,7 @@ impl Accessor for Backend {
         }
     }
 
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, BytesReader)> {
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, OutputBytesReader)> {
         let resp = self.s3_get_object(path, args.range()).await?;
 
         let status = resp.status();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Split bytes reader into input and output

We have different requirement for user input and opendal's output.
