### PR TITLE
fix: Allow range_read to be retired

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -256,6 +256,14 @@ impl Error {
         self
     }
 
+    /// Operate on error with map.
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        f(self)
+    }
+
     /// Set permenent status for error.
     pub fn set_permanent(mut self) -> Self {
         self.status = ErrorStatus::Permanent;

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -408,10 +408,11 @@ impl Object {
                 .with_context("path", self.path())
                 .with_context("range", &br.to_string())
                 .map(|e| {
-                    if err.kind() == std::io::ErrorKind::Interrupted {
-                        e.set_temporary()
-                    } else {
-                        e
+                    use std::io::ErrorKind;
+
+                    match err.kind() {
+                        ErrorKind::Interrupted | ErrorKind::UnexpectedEof => e.set_temporary(),
+                        _ => e,
                     }
                 })
                 .set_source(err)

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -407,6 +407,13 @@ impl Object {
                 .with_context("service", self.accessor().metadata().scheme().into_static())
                 .with_context("path", self.path())
                 .with_context("range", &br.to_string())
+                .map(|e| {
+                    if err.kind() == std::io::ErrorKind::Interrupted {
+                        e.set_temporary()
+                    } else {
+                        e
+                    }
+                })
                 .set_source(err)
         })?;
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: Allow range_read to be retired
