### PR TITLE
fix: ghac shall return ObjectAlreadyExists for writing the same path

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,8 @@ pub enum ErrorKind {
     ObjectIsADirectory,
     /// Object is not a directory.
     ObjectNotADirectory,
+    /// Object already exists thus we failed to the specified operation on it.
+    ObjectAlreadyExists,
 }
 
 impl ErrorKind {
@@ -90,6 +92,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::ObjectPermissionDenied => "ObjectPermissionDenied",
             ErrorKind::ObjectIsADirectory => "ObjectIsADirectory",
             ErrorKind::ObjectNotADirectory => "ObjectNotADirectory",
+            ErrorKind::ObjectAlreadyExists => "ObjectAlreadyExists",
         }
     }
 }

--- a/src/services/ghac/error.rs
+++ b/src/services/ghac/error.rs
@@ -26,6 +26,7 @@ pub async fn parse_error(resp: Response<IncomingAsyncBody>) -> Result<Error> {
 
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND | StatusCode::NO_CONTENT => (ErrorKind::ObjectNotFound, false),
+        StatusCode::CONFLICT => (ErrorKind::ObjectAlreadyExists, false),
         StatusCode::FORBIDDEN => (ErrorKind::ObjectPermissionDenied, false),
         StatusCode::INTERNAL_SERVER_ERROR
         | StatusCode::BAD_GATEWAY


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: ghac shall return ObjectAlreadyExists for writing the same path

fixed https://github.com/datafuselabs/opendal/issues/1155
