### PR TITLE
fix(services/memcached): TcpStream should only accept host:port

### DIFF
--- a/.github/workflows/service_test_memcached.yml
+++ b/.github/workflows/service_test_memcached.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test
         shell: bash
-        run: cargo test redis --features compress,services-memcached -- --nocapture
+        run: cargo test memcached --features compress,services-memcached -- --nocapture
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/memcached): TcpStream should only accept host:port
