### PR TITLE
doc: fix name change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Access data **efficiently**
 use anyhow::Result;
 use futures::StreamExt;
 use futures::TryStreamExt;
-use opendal::ObjectStreamer;
+use opendal::ObjectReader;
 use opendal::Object;
 use opendal::ObjectMetadata;
 use opendal::ObjectMode;
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     let op = Operator::from_env(Scheme::Fs)?;
 
     // Create object handler.
-    let o = op.object("test_file");
+    let o = op.object("/tmp/test_file");
 
     // Write data info object;
     o.write("Hello, World!").await?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR
This `PR` fix function name change in README quick start.
also change dir to  `/tmp/test_file`(like examples) because when use `mac` may cause 
`read-only filesystem or storage medium, source: Read-only file system (os error 30)` problem.
its a little confusion for new users to use `quick start`
![image](https://user-images.githubusercontent.com/15976103/211966281-d3bd74c1-a7a5-498b-942c-aedfeed78cb9.png)
