### PR TITLE
chore(deps): replace dotenv with dotenvy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ base64 = "0.21"
 bb8 = { version = "0.8", optional = true }
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 bytes = "1"
-dotenv = { version = "0.15", optional = true }
 flagset = "0.4"
 futures = { version = "0.3", features = ["alloc"] }
 hdrs = { version = "0.2", optional = true, features = ["async_file"] }
@@ -156,7 +155,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 cfg-if = "1"
 criterion = { version = "0.4", features = ["async", "async_tokio"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 env_logger = "0.10"
 itertools = "0.10"
 opentelemetry = { version = "0.17", default-features = false, features = [

--- a/benches/layers.rs
+++ b/benches/layers.rs
@@ -50,7 +50,7 @@ pub static TOKIO: Lazy<tokio::runtime::Runtime> =
 fn bench_tracing_layer(c: &mut Criterion) {
     let mut group = c.benchmark_group("tracing_layers");
 
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
     let op = Operator::from_env(Scheme::S3).expect("init operator must succeed");
     let layered_op = Operator::from_env(Scheme::S3)
         .expect("init operator must succeed")

--- a/benches/ops/utils.rs
+++ b/benches/ops/utils.rs
@@ -39,7 +39,7 @@ async fn service(scheme: Scheme) -> Option<Operator> {
 }
 
 pub fn services() -> Vec<(&'static str, Option<Operator>)> {
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     TOKIO.block_on(async {
         vec![

--- a/examples/tracing_layer.rs
+++ b/examples/tracing_layer.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let root = span!(tracing::Level::INFO, "app_start", work_units = 2);
         let _enter = root.enter();
 
-        let _ = dotenv::dotenv();
+        let _ = dotenvy::dotenv();
         let op = Operator::from_env(Scheme::S3)
             .expect("init operator must succeed")
             .layer(TracingLayer);

--- a/tests/behavior/utils.rs
+++ b/tests/behavior/utils.rs
@@ -34,7 +34,7 @@ use sha2::Sha256;
 /// - Else, returns a `None` to represent no valid config for operator.
 pub fn init_service(scheme: Scheme, random_root: bool) -> Option<Operator> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
 
     let prefix = format!("opendal_{}_", scheme);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

+ Removes the `dotenv` dependency since it is not used anywhere.
+ Replaces the `dotenv` dev-dependency with `dotenvy`.
+ Resolves #1186 

