### PR TITLE
feat: Allow setting http client that built from external

### DIFF
--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -274,7 +274,10 @@ impl Builder {
         }?;
         debug!("backend use endpoint {}", &container);
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Azblob)
+        })?;
 
         let mut signer_builder = AzureStorageSigner::builder();
         if let Some(sas_token) = &self.sas_token {

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -46,6 +46,7 @@ pub struct Builder {
     account_name: Option<String>,
     account_key: Option<String>,
     sas_token: Option<String>,
+    http_client: Option<HttpClient>,
 }
 
 impl Debug for Builder {
@@ -140,6 +141,17 @@ impl Builder {
             self.sas_token = Some(sas_token.to_string());
         }
 
+        self
+    }
+
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
         self
     }
 
@@ -274,10 +286,14 @@ impl Builder {
         }?;
         debug!("backend use endpoint {}", &container);
 
-        let client = HttpClient::new().map_err(|err| {
-            err.with_operation("Builder::build")
-                .with_context("service", Scheme::Azblob)
-        })?;
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Azblob)
+            })?
+        };
 
         let mut signer_builder = AzureStorageSigner::builder();
         if let Some(sas_token) = &self.sas_token {

--- a/src/services/azdfs/backend.rs
+++ b/src/services/azdfs/backend.rs
@@ -151,7 +151,7 @@ impl Builder {
             true => Err(
                 Error::new(ErrorKind::BackendConfigInvalid, "filesystem is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::Azblob),
+                    .with_context("service", Scheme::Azdfs),
             ),
         }?;
         debug!("backend use filesystem {}", &filesystem);
@@ -161,12 +161,15 @@ impl Builder {
             None => Err(
                 Error::new(ErrorKind::BackendConfigInvalid, "endpoint is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::Azblob),
+                    .with_context("service", Scheme::Azdfs),
             ),
         }?;
         debug!("backend use endpoint {}", &filesystem);
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Azdfs)
+        })?;
 
         let mut signer_builder = AzureStorageSigner::builder();
         if let (Some(name), Some(key)) = (&self.account_name, &self.account_key) {

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -186,7 +186,11 @@ impl Builder {
         // TODO: server side encryption
 
         // build http client
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Gcs)
+        })?;
+
         let endpoint = self
             .endpoint
             .clone()

--- a/src/services/ghac/backend.rs
+++ b/src/services/ghac/backend.rs
@@ -150,7 +150,10 @@ impl Builder {
             api_token: env::var(GITHUB_TOKEN).unwrap_or_default(),
             repo: env::var(GITHUB_REPOSITORY).unwrap_or_default(),
 
-            client: HttpClient::new(),
+            client: HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Ghac)
+            })?,
         };
 
         Ok(apply_wrapper(backend))

--- a/src/services/ghac/backend.rs
+++ b/src/services/ghac/backend.rs
@@ -61,6 +61,8 @@ pub struct Builder {
     root: Option<String>,
     version: Option<String>,
     enable_create_simulation: bool,
+
+    http_client: Option<HttpClient>,
 }
 
 impl Builder {
@@ -113,12 +115,32 @@ impl Builder {
         self
     }
 
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
+        self
+    }
+
     /// Build a github action cache runner.
     pub fn build(&mut self) -> Result<impl Accessor> {
         debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.root.take().unwrap_or_default());
         debug!("backend use root {}", root);
+
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Ghac)
+            })?
+        };
 
         let backend = Backend {
             root,
@@ -150,10 +172,7 @@ impl Builder {
             api_token: env::var(GITHUB_TOKEN).unwrap_or_default(),
             repo: env::var(GITHUB_REPOSITORY).unwrap_or_default(),
 
-            client: HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Ghac)
-            })?,
+            client,
         };
 
         Ok(apply_wrapper(backend))

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -30,6 +30,7 @@ use crate::*;
 pub struct Builder {
     endpoint: Option<String>,
     root: Option<String>,
+    http_client: Option<HttpClient>,
 }
 
 impl Debug for Builder {
@@ -82,6 +83,17 @@ impl Builder {
         self
     }
 
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
+        self
+    }
+
     /// Build a HTTP backend.
     pub fn build(&mut self) -> Result<impl Accessor> {
         debug!("backend build started: {:?}", &self);
@@ -99,10 +111,14 @@ impl Builder {
         let root = normalize_root(&self.root.take().unwrap_or_default());
         debug!("backend use root {}", root);
 
-        let client = HttpClient::new().map_err(|err| {
-            err.with_operation("Builder::build")
-                .with_context("service", Scheme::Http)
-        })?;
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Http)
+            })?
+        };
 
         debug!("backend build finished: {:?}", &self);
         Ok(apply_wrapper(Backend {

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -99,7 +99,10 @@ impl Builder {
         let root = normalize_root(&self.root.take().unwrap_or_default());
         debug!("backend use root {}", root);
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Http)
+        })?;
 
         debug!("backend build finished: {:?}", &self);
         Ok(apply_wrapper(Backend {

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -115,7 +115,10 @@ impl Builder {
         Ok(apply_wrapper(Backend {
             root,
             endpoint,
-            client: HttpClient::new(),
+            client: HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Azblob)
+            })?,
         }))
     }
 }

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -33,6 +33,7 @@ use crate::*;
 pub struct Builder {
     endpoint: Option<String>,
     root: Option<String>,
+    http_client: Option<HttpClient>,
 }
 
 impl Builder {
@@ -86,6 +87,17 @@ impl Builder {
         self
     }
 
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
+        self
+    }
+
     /// Consume builder to build an ipfs backend.
     pub fn build(&mut self) -> Result<impl Accessor> {
         debug!("backend build started: {:?}", &self);
@@ -111,14 +123,20 @@ impl Builder {
         }?;
         debug!("backend use endpoint {}", &endpoint);
 
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Ipfs)
+            })?
+        };
+
         debug!("backend build finished: {:?}", &self);
         Ok(apply_wrapper(Backend {
             root,
             endpoint,
-            client: HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Azblob)
-            })?,
+            client,
         }))
     }
 }

--- a/src/services/ipmfs/builder.rs
+++ b/src/services/ipmfs/builder.rs
@@ -17,6 +17,7 @@ use log::debug;
 use super::backend::Backend;
 use crate::raw::*;
 use crate::Result;
+use crate::Scheme;
 
 /// Builder for service ipfs.
 #[derive(Default, Debug)]
@@ -74,7 +75,10 @@ impl Builder {
             .clone()
             .unwrap_or_else(|| "http://localhost:5001".to_string());
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Ipmfs)
+        })?;
 
         debug!("backend build finished: {:?}", &self);
         Ok(apply_wrapper(Backend::new(root, client, endpoint)))

--- a/src/services/obs/backend.rs
+++ b/src/services/obs/backend.rs
@@ -175,7 +175,10 @@ impl Builder {
 
         debug!("backend use endpoint {}", &endpoint);
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::Obs)
+        })?;
 
         let mut signer_builder = HuaweicloudObsSigner::builder();
         if let (Some(access_key_id), Some(secret_access_key)) =

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -252,7 +252,10 @@ impl Builder {
             endpoint,
             presign_endpoint,
             host,
-            client: HttpClient::new(),
+            client: HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Oss)
+            })?,
             bucket: self.bucket.clone(),
             signer: Arc::new(signer),
         }))

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -47,6 +47,8 @@ pub struct Builder {
     access_key_secret: Option<String>,
 
     allow_anonymous: bool,
+
+    http_client: Option<HttpClient>,
 }
 
 impl Debug for Builder {
@@ -167,6 +169,17 @@ impl Builder {
         self
     }
 
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
+        self
+    }
+
     /// preprocess the endpoint option
     fn parse_endpoint(&self, endpoint: &Option<String>, bucket: &str) -> Result<(String, String)> {
         let (endpoint, host) = match endpoint.clone() {
@@ -197,7 +210,7 @@ impl Builder {
     }
 
     /// finish building
-    pub fn build(&self) -> Result<impl Accessor> {
+    pub fn build(&mut self) -> Result<impl Accessor> {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.root.clone().unwrap_or_default());
@@ -211,6 +224,15 @@ impl Builder {
                     .with_context("service", Scheme::Oss),
             ),
         }?;
+
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::Oss)
+            })?
+        };
 
         // Retrieve endpoint and host by parsing the endpoint option and bucket. If presign_endpoint is not
         // set, take endpoint as default presign_endpoint.
@@ -252,10 +274,7 @@ impl Builder {
             endpoint,
             presign_endpoint,
             host,
-            client: HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Oss)
-            })?,
+            client,
             bucket: self.bucket.clone(),
             signer: Arc::new(signer),
         }))

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -682,7 +682,10 @@ impl Builder {
                 })?),
             };
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", Scheme::S3)
+        })?;
 
         let cfg = AwsConfigLoader::default();
         if !self.disable_config_load {
@@ -1441,7 +1444,7 @@ mod tests {
     fn test_region() {
         let _ = env_logger::try_init();
 
-        let client = HttpClient::new();
+        let client = HttpClient::new().unwrap();
 
         let endpoint_cases = vec![
             Some("s3.amazonaws.com"),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

feat: Allow setting http client that built from external
