### PR TITLE
feat: Allow passing content_type to OSS presign

### DIFF
--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -1536,7 +1536,6 @@ impl Object {
         self.presign_write_with(OpWrite::new(0), expire)
     }
 
-
     /// Presign an operation for write with option described in OpenDAL [rfc-0661](../../docs/rfcs/0661-path-in-accessor.md)
     ///
     /// You can pass `OpWrite` to this method to specify the content length and content type.
@@ -1547,6 +1546,7 @@ impl Object {
     /// use anyhow::Result;
     /// use futures::io;
     /// use opendal::services::memory;
+    /// use opendal::OpWrite;
     /// use opendal::Operator;
     /// use time::Duration;
     /// use opendal::Scheme;

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -1533,7 +1533,39 @@ impl Object {
     /// # }
     /// ```
     pub fn presign_write(&self, expire: Duration) -> Result<PresignedRequest> {
-        let op = OpPresign::new(OpWrite::new(0), expire);
+        self.presign_write_with(OpWrite::new(0), expire)
+    }
+
+
+    /// Presign an operation for write with option described in OpenDAL [rfc-0661](../../docs/rfcs/0661-path-in-accessor.md)
+    ///
+    /// You can pass `OpWrite` to this method to specify the content length and content type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use futures::io;
+    /// use opendal::services::memory;
+    /// use opendal::Operator;
+    /// use time::Duration;
+    /// use opendal::Scheme;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    /// #    let op = Operator::from_env(Scheme::Memory)?;
+    ///     let args = OpWrite::new(0).with_content_type("text/csv");
+    ///     let signed_req = op.object("test").presign_write_with(args, Duration::hours(1))?;
+    ///     let req = http::Request::builder()
+    ///         .method(signed_req.method())
+    ///         .uri(signed_req.uri())
+    ///         .body(())?;
+    ///
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn presign_write_with(&self, op: OpWrite, expire: Duration) -> Result<PresignedRequest> {
+        let op = OpPresign::new(op, expire);
 
         let rp = self.acc.presign(self.path(), op)?;
         Ok(rp.into_presigned_request())

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -78,7 +78,6 @@ pub struct OpWriteMultipart {
     upload_id: String,
     part_number: usize,
     size: u64,
-    content_type: Option<String>,
 }
 
 impl OpWriteMultipart {
@@ -88,15 +87,6 @@ impl OpWriteMultipart {
             upload_id,
             part_number,
             size,
-            content_type: None,
-        }
-    }
-
-    /// Set the content type of option
-    pub fn with_content_type(self, content_type: &str) -> Self {
-        Self {
-            content_type: Some(content_type.to_string()),
-            ..self
         }
     }
 
@@ -108,11 +98,6 @@ impl OpWriteMultipart {
     /// Get part_number from option.
     pub fn part_number(&self) -> usize {
         self.part_number
-    }
-
-    /// Get content_type from option.
-    pub fn content_type(&self) -> Option<&str> {
-        self.content_type.as_deref()
     }
 
     /// Get size from option.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -78,6 +78,7 @@ pub struct OpWriteMultipart {
     upload_id: String,
     part_number: usize,
     size: u64,
+    content_type: Option<String>,
 }
 
 impl OpWriteMultipart {
@@ -87,6 +88,15 @@ impl OpWriteMultipart {
             upload_id,
             part_number,
             size,
+            content_type: None,
+        }
+    }
+
+    /// Set the content type of option
+    pub fn with_content_type(self, content_type: &str) -> Self {
+        Self {
+            content_type: Some(content_type.to_string()),
+            ..self
         }
     }
 
@@ -98,6 +108,11 @@ impl OpWriteMultipart {
     /// Get part_number from option.
     pub fn part_number(&self) -> usize {
         self.part_number
+    }
+
+    /// Get content_type from option.
+    pub fn content_type(&self) -> Option<&str> {
+        self.content_type.as_deref()
     }
 
     /// Get size from option.

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -419,8 +419,8 @@ impl Accessor for Backend {
         let mut req = match args.operation() {
             PresignOperation::Stat(_) => self.oss_head_object_request(path, true)?,
             PresignOperation::Read(v) => self.oss_get_object_request(path, v.range(), true)?,
-            PresignOperation::Write(_) => {
-                self.oss_put_object_request(path, None, None, AsyncBody::Empty, true)?
+            PresignOperation::Write(v) => {
+                self.oss_put_object_request(path, None, v.content_type(), AsyncBody::Empty, true)?
             }
             _ => {
                 return Err(Error::new(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Currently, there's no content-type header at all in the current presign operation. However, browsers have a limit about there's no way to NOT passing Content-Type on a `fetch()` operation. Thus it's hard to do upload presigned urls in a website.

This PR allows passing content-type on presign write operations:

- addes `presign_write_with` method to Object
- passes the content_type argument on presigning write operations

fixes #421