### PR TITLE
[NEED DISCUSSION] feat: builder methods can accept String type to avoid coping

### DIFF
--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -50,7 +50,6 @@ impl Builder {
         let mut builder = Builder::default();
 
         for (k, v) in it {
-            let v = v.as_str();
             match k.as_ref() {
                 "root" => builder.root(v),
                 "endpoint" => builder.endpoint(v),
@@ -64,24 +63,20 @@ impl Builder {
     /// Set endpoint for http backend.
     ///
     /// For example: `https://example.com`
-    pub fn endpoint(&mut self, endpoint: &str) -> &mut Self {
+    pub fn endpoint(&mut self, endpoint: impl Into<String>) -> &mut Self {
+        let endpoint = endpoint.into();
         self.endpoint = if endpoint.is_empty() {
             None
         } else {
-            Some(endpoint.to_string())
+            Some(endpoint)
         };
-
         self
     }
 
     /// Set root path of http backend.
-    pub fn root(&mut self, root: &str) -> &mut Self {
-        self.root = if root.is_empty() {
-            None
-        } else {
-            Some(root.to_string())
-        };
-
+    pub fn root(&mut self, root: impl Into<String>) -> &mut Self {
+        let root = root.into();
+        self.root = if root.is_empty() { None } else { Some(root) };
         self
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

current implementation of `Builder`'s methods only accept `&str` as paramaters, which may need a copy operation if the caller own a `String` type. and the PR is to enhance the method to accept `String` type and `&str`.

### Pros
- `String` type is also acceptable
- avoid coping the variable in method `from_iter` in `Builder`

### Cons
 - will bloat the compile time due to `impl Into<String>` usage
 - need to bump a minor version due to the change of methods' signature (though the signatures are compatable)

here is the MVP of the change, if it looks good to you, I can help to modify other builders as well.

let me know if you have any opinion. 