### PR TITLE
fix: FsBuilder can't be used with empty root anymore

### DIFF
--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -18,6 +18,8 @@ use opendal::Operator;
 
 #[napi]
 pub fn debug() -> String {
-    let op = Operator::from_env::<services::Fs>().unwrap().finish();
+    let op = Operator::create(services::Memory::default())
+        .unwrap()
+        .finish();
     format!("{:?}", op.metadata())
 }

--- a/bindings/object_store/src/lib.rs
+++ b/bindings/object_store/src/lib.rs
@@ -223,7 +223,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic() {
-        let op = Operator::from_env::<services::Memory>().unwrap().finish();
+        let op = Operator::create(services::Memory::default())
+            .unwrap()
+            .finish();
         let object_store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(op));
 
         // Retrieve a specific file

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -18,7 +18,9 @@ use pyo3::prelude::*;
 
 #[pyfunction]
 fn debug() -> PyResult<String> {
-    let op = Operator::from_env::<services::Fs>().unwrap().finish();
+    let op = Operator::create(services::Memory::default())
+        .unwrap()
+        .finish();
     Ok(format!("{:?}", op.metadata()))
 }
 

--- a/src/layers/chaos.rs
+++ b/src/layers/chaos.rs
@@ -51,7 +51,7 @@ use crate::*;
 /// use opendal::Operator;
 /// use opendal::Scheme;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(ChaosLayer::new(0.1))
 ///     .finish();

--- a/src/layers/concurrent_limit.rs
+++ b/src/layers/concurrent_limit.rs
@@ -37,7 +37,7 @@ use crate::*;
 /// use opendal::Operator;
 /// use opendal::Scheme;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(ConcurrentLimitLayer::new(1024))
 ///     .finish();

--- a/src/layers/logging.rs
+++ b/src/layers/logging.rs
@@ -58,7 +58,7 @@ use crate::*;
 /// use opendal::Operator;
 /// use opendal::Scheme;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(LoggingLayer::default())
 ///     .finish();

--- a/src/layers/metrics.rs
+++ b/src/layers/metrics.rs
@@ -92,7 +92,7 @@ static LABEL_ERROR: &str = "error";
 /// use opendal::services;
 /// use opendal::Operator;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(MetricsLayer)
 ///     .finish();

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -42,7 +42,7 @@ use crate::*;
 /// use opendal::Operator;
 /// use opendal::Scheme;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(RetryLayer::new(ExponentialBackoff::default()))
 ///     .finish();
@@ -64,7 +64,7 @@ where
     /// use opendal::Operator;
     /// use opendal::Scheme;
     ///
-    /// let _ = Operator::from_env::<services::Fs>()
+    /// let _ = Operator::create(services::Memory::default())
     ///     .expect("must init")
     ///     .layer(RetryLayer::new(ExponentialBackoff::default()));
     /// ```

--- a/src/layers/tracing.rs
+++ b/src/layers/tracing.rs
@@ -40,7 +40,7 @@ use crate::*;
 /// use opendal::services;
 /// use opendal::Operator;
 ///
-/// let _ = Operator::from_env::<services::Fs>()
+/// let _ = Operator::create(services::Memory::default())
 ///     .expect("must init")
 ///     .layer(TracingLayer)
 ///     .finish();

--- a/src/raw/io/output/into_reader/by_range.rs
+++ b/src/raw/io/output/into_reader/by_range.rs
@@ -138,7 +138,12 @@ impl<A: Accessor> output::Read for RangeReader<A> {
                 // TODO
                 //
                 // we can use RpRead returned here to correct size.
-                let (_, r) = ready!(Pin::new(fut).poll(cx))?;
+                let (_, r) = ready!(Pin::new(fut).poll(cx)).map_err(|err| {
+                    // If read future retruns an error, we should reset
+                    // state to Idle so that we can retry it.
+                    self.state = State::Idle;
+                    err
+                })?;
 
                 self.state = State::Reading(r);
                 self.poll_read(cx, buf)
@@ -230,7 +235,12 @@ impl<A: Accessor> output::Read for RangeReader<A> {
                 // TODO
                 //
                 // we can use RpRead returned here to correct size.
-                let (_, r) = ready!(Pin::new(fut).poll(cx))?;
+                let (_, r) = ready!(Pin::new(fut).poll(cx)).map_err(|err| {
+                    // If read future retruns an error, we should reset
+                    // state to Idle so that we can retry it.
+                    self.state = State::Idle;
+                    err
+                })?;
 
                 self.state = State::Reading(r);
                 self.poll_next(cx)

--- a/src/raw/layer.rs
+++ b/src/raw/layer.rs
@@ -304,7 +304,7 @@ mod tests {
     use futures::lock::Mutex;
 
     use super::*;
-    use crate::services::Fs;
+    use crate::services::Memory;
 
     #[derive(Debug)]
     struct Test<A: Accessor> {
@@ -353,7 +353,7 @@ mod tests {
             deleted: Arc::new(Mutex::new(false)),
         };
 
-        let op = Operator::create(Fs::default())
+        let op = Operator::create(Memory::default())
             .unwrap()
             .layer(&test)
             .finish();


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix: FsBuilder can't be used with empty root anymore
