### PR TITLE
refactor: Don't expose ops structs to users directly

### DIFF
--- a/src/layers/chaos.rs
+++ b/src/layers/chaos.rs
@@ -22,6 +22,7 @@ use futures::FutureExt;
 use rand::prelude::*;
 use rand::rngs::StdRng;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/complete_reader.rs
+++ b/src/layers/complete_reader.rs
@@ -21,6 +21,7 @@ use std::task::Poll;
 
 use async_trait::async_trait;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/concurrent_limit.rs
+++ b/src/layers/concurrent_limit.rs
@@ -23,6 +23,7 @@ use bytes::Bytes;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/error_context.rs
+++ b/src/layers/error_context.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use async_trait::async_trait;
 use futures::TryFutureExt;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -20,6 +20,7 @@ use std::mem;
 use async_trait::async_trait;
 
 use crate::object::*;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/logging.rs
+++ b/src/layers/logging.rs
@@ -29,6 +29,7 @@ use log::log;
 use log::trace;
 use log::Level;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/metrics.rs
+++ b/src/layers/metrics.rs
@@ -33,6 +33,7 @@ use metrics::register_histogram;
 use metrics::Counter;
 use metrics::Histogram;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -31,6 +31,7 @@ use futures::ready;
 use futures::FutureExt;
 use log::warn;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 
@@ -640,15 +641,16 @@ impl<R: output::BlockingRead> output::BlockingRead for RetryReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::anyhow;
-    use async_trait::async_trait;
-    use bytes::Bytes;
-    use futures::AsyncReadExt;
     use std::io;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::task::Context;
     use std::task::Poll;
+
+    use anyhow::anyhow;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::AsyncReadExt;
 
     use super::*;
 

--- a/src/layers/tracing.rs
+++ b/src/layers/tracing.rs
@@ -25,6 +25,7 @@ use futures::AsyncRead;
 use futures::FutureExt;
 use tracing::Span;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/layers/type_eraser.rs
+++ b/src/layers/type_eraser.rs
@@ -17,6 +17,7 @@ use std::fmt::Formatter;
 
 use async_trait::async_trait;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,24 +92,11 @@ pub use error::Error;
 pub use error::ErrorKind;
 pub use error::Result;
 
-mod ops;
-pub use ops::OpAbortMultipart;
-pub use ops::OpCompleteMultipart;
-pub use ops::OpCreate;
-pub use ops::OpCreateMultipart;
-pub use ops::OpDelete;
-pub use ops::OpList;
-pub use ops::OpPresign;
-pub use ops::OpRead;
-pub use ops::OpStat;
-pub use ops::OpWrite;
-pub use ops::OpWriteMultipart;
-pub use ops::PresignOperation;
-
 // Public modules, they will be accessed like `opendal::layers::Xxxx`
 #[cfg(feature = "docs")]
 pub mod docs;
 pub mod layers;
+pub mod ops;
 pub mod raw;
 pub mod services;
 

--- a/src/object/blocking_reader.rs
+++ b/src/object/blocking_reader.rs
@@ -21,10 +21,10 @@ use parking_lot::Mutex;
 
 use crate::error::Error;
 use crate::error::Result;
+use crate::ops::OpRead;
 use crate::raw::*;
 use crate::ErrorKind;
 use crate::ObjectMetadata;
-use crate::OpRead;
 
 /// BlockingObjectReader is the public API for users.
 pub struct BlockingObjectReader {

--- a/src/object/multipart.rs
+++ b/src/object/multipart.rs
@@ -15,6 +15,7 @@
 use futures::io::Cursor;
 use time::Duration;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -28,6 +28,7 @@ use tokio::io::ReadBuf;
 use super::BlockingObjectLister;
 use super::BlockingObjectReader;
 use super::ObjectLister;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 
@@ -716,12 +717,10 @@ impl Object {
     /// # Examples
     ///
     /// ```no_run
-    /// # use opendal::OpWrite;
     /// # use std::io::Result;
     /// # use opendal::Operator;
-    /// # use futures::StreamExt;
-    /// # use futures::SinkExt;
     /// use bytes::Bytes;
+    /// use opendal::ops::OpWrite;
     ///
     /// # #[tokio::main]
     /// # async fn test(op: Operator) -> Result<()> {
@@ -791,13 +790,10 @@ impl Object {
     /// # Examples
     ///
     /// ```no_run
-    /// # use opendal::OpWrite;
-    /// # use std::io::Result;
+    /// # use opendal::Result;
     /// # use opendal::Operator;
-    /// # use futures::StreamExt;
-    /// # use futures::SinkExt;
-    /// # use opendal::Scheme;
     /// use bytes::Bytes;
+    /// use opendal::ops::OpWrite;
     ///
     /// # async fn test(op: Operator) -> Result<()> {
     /// let o = op.object("hello.txt");
@@ -1437,7 +1433,7 @@ impl Object {
     /// ```no_run
     /// use anyhow::Result;
     /// use futures::io;
-    /// use opendal::OpWrite;
+    /// use opendal::ops::OpWrite;
     /// use opendal::Operator;
     /// use time::Duration;
     ///

--- a/src/object/reader.rs
+++ b/src/object/reader.rs
@@ -24,8 +24,8 @@ use futures::AsyncSeek;
 use futures::Stream;
 
 use crate::error::Result;
+use crate::ops::OpRead;
 use crate::raw::*;
-use crate::OpRead;
 
 /// ObjectReader is the public API for users.
 ///

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Ops provides the operation args struct like [`OpRead`] for user.
+//!
+//! By using ops, users can add more context for operation.
+
 use time::Duration;
 
 use crate::raw::*;

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use flagset::flags;
 use flagset::FlagSet;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/raw/adapters/kv/backend.rs
+++ b/src/raw/adapters/kv/backend.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use futures::AsyncReadExt;
 
 use super::Adapter;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/raw/io/output/into_reader/by_range.rs
+++ b/src/raw/io/output/into_reader/by_range.rs
@@ -27,6 +27,7 @@ use futures::future::BoxFuture;
 use futures::ready;
 use tokio::io::ReadBuf;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/raw/io/walk.rs
+++ b/src/raw/io/walk.rs
@@ -18,6 +18,7 @@ use std::mem;
 use async_trait::async_trait;
 
 use crate::object::*;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/raw/layer.rs
+++ b/src/raw/layer.rs
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 
@@ -42,6 +43,7 @@ use crate::*;
 /// use std::sync::Arc;
 ///
 /// use async_trait::async_trait;
+/// use opendal::ops::*;
 /// use opendal::raw::*;
 /// use opendal::*;
 ///

--- a/src/services/azblob/backend.rs
+++ b/src/services/azblob/backend.rs
@@ -32,6 +32,7 @@ use reqsign::AzureStorageSigner;
 use super::dir_stream::DirStream;
 use super::error::parse_error;
 use crate::object::ObjectMetadata;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/azdfs/backend.rs
+++ b/src/services/azdfs/backend.rs
@@ -31,6 +31,7 @@ use reqsign::AzureStorageSigner;
 use super::dir_stream::DirStream;
 use super::error::parse_error;
 use crate::object::ObjectMetadata;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -16,7 +16,8 @@ use std::cmp::min;
 use std::collections::HashMap;
 use std::io;
 use std::io::SeekFrom;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 
 use async_compat::Compat;
 use async_trait::async_trait;
@@ -29,6 +30,7 @@ use super::dir_stream::BlockingDirPager;
 use super::dir_stream::DirPager;
 use super::error::parse_io_error;
 use crate::object::*;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/fs/dir_stream.rs
+++ b/src/services/fs/dir_stream.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+use std::path::PathBuf;
+
 use async_trait::async_trait;
-use std::path::{Path, PathBuf};
 
 use super::error::parse_io_error;
 use crate::raw::*;

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -39,6 +39,7 @@ use tokio::sync::OnceCell;
 use super::dir_stream::DirStream;
 use super::dir_stream::ReadDir;
 use super::util::FtpReader;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -35,6 +35,7 @@ use super::dir_stream::DirStream;
 use super::error::parse_error;
 use super::error::parse_json_deserialize_error;
 use super::uri::percent_encode_path;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/ghac/backend.rs
+++ b/src/services/ghac/backend.rs
@@ -31,6 +31,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::error::parse_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -26,6 +26,7 @@ use time::OffsetDateTime;
 
 use super::dir_stream::DirStream;
 use super::error::parse_io_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -23,6 +23,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::error::parse_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -26,6 +26,7 @@ use prost::Message;
 
 use super::error::parse_error;
 use super::ipld::PBNode;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/ipmfs/backend.rs
+++ b/src/services/ipmfs/backend.rs
@@ -26,6 +26,7 @@ use serde::Deserialize;
 use super::dir_stream::DirStream;
 use super::error::parse_error;
 use super::error::parse_json_deserialize_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/obs/backend.rs
+++ b/src/services/obs/backend.rs
@@ -29,6 +29,7 @@ use reqsign::HuaweicloudObsSigner;
 
 use super::dir_stream::DirStream;
 use super::error::parse_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -31,6 +31,7 @@ use reqsign::AliyunOssSigner;
 
 use super::dir_stream::DirStream;
 use super::error::parse_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -25,6 +25,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::error::parse_error;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/webhdfs/backend.rs
+++ b/src/services/webhdfs/backend.rs
@@ -33,6 +33,7 @@ use super::message::FileStatusType;
 use super::message::FileStatusWrapper;
 use super::message::FileStatusesWrapper;
 use super::message::Redirection;
+use crate::ops::*;
 use crate::raw::*;
 use crate::*;
 

--- a/src/services/webhdfs/message.rs
+++ b/src/services/webhdfs/message.rs
@@ -84,9 +84,10 @@ pub(super) enum FileStatusType {
 
 #[cfg(test)]
 mod test {
-    use crate::{raw::ObjectPage, services::webhdfs::dir_stream::DirStream, ObjectMode};
-
     use super::*;
+    use crate::raw::ObjectPage;
+    use crate::services::webhdfs::dir_stream::DirStream;
+    use crate::ObjectMode;
 
     #[test]
     fn test_file_statuses() {


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Don't expose ops structs to users directly
