### PR TITLE
chore: fix name typo in oss backend

### DIFF
--- a/src/services/oss/backend.rs
+++ b/src/services/oss/backend.rs
@@ -476,7 +476,7 @@ impl Accessor for OssBackend {
     }
 
     async fn delete(&self, path: &str, _: OpDelete) -> Result<RpDelete> {
-        let resp = self.obs_delete_object(path).await?;
+        let resp = self.oss_delete_object(path).await?;
         let status = resp.status();
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => {
@@ -668,7 +668,7 @@ impl OssBackend {
         self.client.send_async(req).await
     }
 
-    async fn obs_delete_object(&self, path: &str) -> Result<Response<IncomingAsyncBody>> {
+    async fn oss_delete_object(&self, path: &str) -> Result<Response<IncomingAsyncBody>> {
         let mut req = self.oss_delete_object_request(path)?;
         self.signer.sign(&mut req).map_err(new_request_sign_error)?;
         self.client.send_async(req).await


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary
Just found a small name typo.