### PR TITLE
feat: Add username and password support for WebDAV

### DIFF
--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -210,7 +210,10 @@ impl Builder for WebdavBuilder {
                 )
             }
             (Some(username), None) => {
-                format!("Basic {}", general_purpose::STANDARD.encode(username))
+                format!(
+                    "Basic {}",
+                    general_purpose::STANDARD.encode(format!("{username}:"))
+                )
             }
             (None, Some(_)) => {
                 return Err(

--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -206,7 +206,7 @@ impl Builder for WebdavBuilder {
             (Some(username), Some(password)) => {
                 format!(
                     "Basic {}",
-                    general_purpose::STANDARD.encode(format!("{}:{}", username, password))
+                    general_purpose::STANDARD.encode(format!("{username}:{password}"))
                 )
             }
             (Some(username), None) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR adds username and password support forWebDAV

Please review the changes, if it's ok I will do the same for `HttpBuilder`

#1319 #1237