### PR TITLE
refactor: Extract scan as a new API and remove ListStyle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ reqwest = { version = "0.11.13", features = [
 rocksdb = { version = "0.19", default-features = false, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sled = {version = "0.34.7", optional = true }
+sled = { version = "0.34.7", optional = true }
 suppaftp = { version = "4.5", default-features = false, features = [
   "async-secure",
   "async-rustls",

--- a/src/layers/chaos.rs
+++ b/src/layers/chaos.rs
@@ -126,8 +126,16 @@ impl<A: Accessor> LayeredAccessor for ChaosAccessor<A> {
         self.inner.list(path, args).await
     }
 
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.inner.scan(path, args).await
+    }
+
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner.blocking_list(path, args)
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        self.inner.blocking_scan(path, args)
     }
 }
 

--- a/src/layers/complete.rs
+++ b/src/layers/complete.rs
@@ -286,6 +286,14 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.complete_blocking_pager(path, args)
     }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        todo!()
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        todo!()
+    }
 }
 
 pub enum CompleteReader<A: Accessor, R> {

--- a/src/layers/complete.rs
+++ b/src/layers/complete.rs
@@ -186,11 +186,11 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
             let p = to_hierarchy_pager(p, path);
             Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
         } else {
-            return Err(
+            Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("list"),
-            );
+            )
         }
     }
 
@@ -212,11 +212,11 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
             let p = to_hierarchy_pager(p, path);
             Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
         } else {
-            return Err(
+            Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("list"),
-            );
+            )
         }
     }
 
@@ -237,11 +237,11 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
             let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
             Ok((RpScan::default(), CompletePager::NeedFlat(p)))
         } else {
-            return Err(
+            Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("scan"),
-            );
+            )
         }
     }
 
@@ -262,11 +262,11 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
             let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
             Ok((RpScan::default(), CompletePager::NeedFlat(p)))
         } else {
-            return Err(
+            Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("scan"),
-            );
+            )
         }
     }
 }

--- a/src/layers/complete.rs
+++ b/src/layers/complete.rs
@@ -168,93 +168,105 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         }
     }
 
-    async fn complete_pager(
+    async fn complete_list(
         &self,
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::Pager>)> {
-        if !self.meta.capabilities().contains(AccessorCapability::List) {
+        let (can_list, can_scan) = (
+            self.meta.capabilities().contains(AccessorCapability::List),
+            self.meta.capabilities().contains(AccessorCapability::Scan),
+        );
+
+        if can_list {
+            let (rp, p) = self.inner.list(path, args).await?;
+            Ok((rp, CompletePager::AlreadyComplete(p)))
+        } else if can_scan {
+            let (_, p) = self.inner.scan(path, OpScan::new()).await?;
+            let p = to_hierarchy_pager(p, path);
+            Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
+        } else {
             return Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("list"),
             );
         }
-
-        let (can_flat, can_hierarchy) = (
-            self.meta.hints().contains(AccessorHint::ListFlat),
-            self.meta.hints().contains(AccessorHint::ListHierarchy),
-        );
-
-        match args.style() {
-            ListStyle::Flat => {
-                if can_flat {
-                    let (rp, p) = self.inner.list(path, args).await?;
-                    Ok((rp, CompletePager::AlreadyComplete(p)))
-                } else if can_hierarchy {
-                    // TODO: Make this size configure.
-                    let p = to_flat_pager(self.inner.clone(), path, 256);
-                    Ok((RpList::default(), CompletePager::NeedFlat(p)))
-                } else {
-                    unreachable!("service that support list can't neither can flat nor can hierarchy, must be a bug")
-                }
-            }
-            ListStyle::Hierarchy => {
-                if can_hierarchy {
-                    let (rp, p) = self.inner.list(path, args).await?;
-                    Ok((rp, CompletePager::AlreadyComplete(p)))
-                } else if can_flat {
-                    let (rp, p) = self.inner.list(path, OpList::new(ListStyle::Flat)).await?;
-                    let p = to_hierarchy_pager(p, path);
-                    Ok((rp, CompletePager::NeedHierarchy(p)))
-                } else {
-                    unreachable!("service that support list can't neither can flat nor can hierarchy, must be a bug")
-                }
-            }
-        }
     }
 
-    fn complete_blocking_pager(
+    fn complete_blocking_list(
         &self,
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::BlockingPager>)> {
-        if !self.meta.capabilities().contains(AccessorCapability::List) {
+        let (can_list, can_scan) = (
+            self.meta.capabilities().contains(AccessorCapability::List),
+            self.meta.capabilities().contains(AccessorCapability::Scan),
+        );
+
+        if can_list {
+            let (rp, p) = self.inner.blocking_list(path, args)?;
+            Ok((rp, CompletePager::AlreadyComplete(p)))
+        } else if can_scan {
+            let (_, p) = self.inner.blocking_scan(path, OpScan::new())?;
+            let p = to_hierarchy_pager(p, path);
+            Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
+        } else {
             return Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
-                    .with_operation("blocking_list"),
+                    .with_operation("list"),
             );
         }
+    }
 
-        let (can_flat, can_hierarchy) = (
-            self.meta.hints().contains(AccessorHint::ListFlat),
-            self.meta.hints().contains(AccessorHint::ListHierarchy),
+    async fn complete_scan(
+        &self,
+        path: &str,
+        args: OpScan,
+    ) -> Result<(RpScan, CompletePager<A, A::Pager>)> {
+        let (can_list, can_scan) = (
+            self.meta.capabilities().contains(AccessorCapability::List),
+            self.meta.capabilities().contains(AccessorCapability::Scan),
         );
 
-        match args.style() {
-            ListStyle::Flat => {
-                if can_flat {
-                    let (rp, p) = self.inner.blocking_list(path, args)?;
-                    Ok((rp, CompletePager::AlreadyComplete(p)))
-                } else {
-                    // TODO: Make this size configure.
-                    let p = to_flat_pager(self.inner.clone(), path, 256);
-                    Ok((RpList::default(), CompletePager::NeedFlat(p)))
-                }
-            }
-            ListStyle::Hierarchy => {
-                if can_hierarchy {
-                    let (rp, p) = self.inner.blocking_list(path, args)?;
-                    Ok((rp, CompletePager::AlreadyComplete(p)))
-                } else {
-                    let (rp, p) = self
-                        .inner
-                        .blocking_list(path, OpList::new(ListStyle::Flat))?;
-                    let p = to_hierarchy_pager(p, path);
-                    Ok((rp, CompletePager::NeedHierarchy(p)))
-                }
-            }
+        if can_scan {
+            let (rp, p) = self.inner.scan(path, args).await?;
+            Ok((rp, CompletePager::AlreadyComplete(p)))
+        } else if can_list {
+            let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
+            Ok((RpScan::default(), CompletePager::NeedFlat(p)))
+        } else {
+            return Err(
+                Error::new(ErrorKind::Unsupported, "operation is not supported")
+                    .with_context("service", self.meta.scheme())
+                    .with_operation("scan"),
+            );
+        }
+    }
+
+    fn complete_blocking_scan(
+        &self,
+        path: &str,
+        args: OpScan,
+    ) -> Result<(RpScan, CompletePager<A, A::BlockingPager>)> {
+        let (can_list, can_scan) = (
+            self.meta.capabilities().contains(AccessorCapability::List),
+            self.meta.capabilities().contains(AccessorCapability::Scan),
+        );
+
+        if can_scan {
+            let (rp, p) = self.inner.blocking_scan(path, args)?;
+            Ok((rp, CompletePager::AlreadyComplete(p)))
+        } else if can_list {
+            let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
+            Ok((RpScan::default(), CompletePager::NeedFlat(p)))
+        } else {
+            return Err(
+                Error::new(ErrorKind::Unsupported, "operation is not supported")
+                    .with_context("service", self.meta.scheme())
+                    .with_operation("scan"),
+            );
         }
     }
 }
@@ -280,19 +292,19 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        self.complete_pager(path, args).await
+        self.complete_list(path, args).await
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
-        self.complete_blocking_pager(path, args)
+        self.complete_blocking_list(path, args)
     }
 
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        todo!()
+        self.complete_scan(path, args).await
     }
 
     fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        todo!()
+        self.complete_blocking_scan(path, args)
     }
 }
 

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -169,6 +169,18 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
         Ok((RpList::default(), ImmutableDir::new(children)))
     }
 
+    async fn scan(&self, path: &str, _: OpScan) -> Result<(RpScan, Self::Pager)> {
+        let mut path = path;
+        if path == "/" {
+            path = ""
+        }
+
+        Ok((
+            RpScan::default(),
+            ImmutableDir::new(self.children_flat(path)),
+        ))
+    }
+
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.inner.blocking_read(path, args)
     }
@@ -185,6 +197,18 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
         };
 
         Ok((RpList::default(), ImmutableDir::new(children)))
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        let mut path = path;
+        if path == "/" {
+            path = ""
+        }
+
+        Ok((
+            RpScan::default(),
+            ImmutableDir::new(self.children_flat(path)),
+        ))
     }
 }
 

--- a/src/layers/metrics.rs
+++ b/src/layers/metrics.rs
@@ -160,6 +160,9 @@ struct MetricsHandler {
     requests_total_list: Counter,
     requests_duration_seconds_list: Histogram,
 
+    requests_total_scan: Counter,
+    requests_duration_seconds_scan: Histogram,
+
     requests_total_presign: Counter,
     requests_duration_seconds_presign: Histogram,
 
@@ -195,6 +198,9 @@ struct MetricsHandler {
 
     requests_total_blocking_list: Counter,
     requests_duration_seconds_blocking_list: Histogram,
+
+    requests_total_blocking_scan: Counter,
+    requests_duration_seconds_blocking_scan: Histogram,
 }
 
 impl MetricsHandler {
@@ -287,6 +293,17 @@ impl MetricsHandler {
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
                 LABEL_OPERATION => Operation::List.into_static(),
+            ),
+
+            requests_total_scan: register_counter!(
+                METRIC_REQUESTS_TOTAL,
+                LABEL_SERVICE => service,
+                LABEL_OPERATION => Operation::Scan.into_static(),
+            ),
+            requests_duration_seconds_scan: register_histogram!(
+                METRIC_REQUESTS_DURATION_SECONDS,
+                LABEL_SERVICE => service,
+                LABEL_OPERATION => Operation::Scan.into_static(),
             ),
 
             requests_total_presign: register_counter!(
@@ -424,6 +441,17 @@ impl MetricsHandler {
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
                 LABEL_OPERATION => Operation::BlockingList.into_static(),
+            ),
+
+            requests_total_blocking_scan: register_counter!(
+                METRIC_REQUESTS_TOTAL,
+                LABEL_SERVICE => service,
+                LABEL_OPERATION => Operation::BlockingScan.into_static(),
+            ),
+            requests_duration_seconds_blocking_scan: register_histogram!(
+                METRIC_REQUESTS_DURATION_SECONDS,
+                LABEL_SERVICE => service,
+                LABEL_OPERATION => Operation::BlockingScan.into_static(),
             ),
         }
     }
@@ -610,6 +638,25 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
             .inspect_err(|e| {
                 self.handle
                     .increment_errors_total(Operation::List, e.kind());
+            })
+            .await
+    }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.handle.requests_total_scan.increment(1);
+
+        let start = Instant::now();
+
+        self.inner
+            .scan(path, args)
+            .inspect_ok(|_| {
+                let dur = start.elapsed().as_secs_f64();
+
+                self.handle.requests_duration_seconds_scan.record(dur);
+            })
+            .inspect_err(|e| {
+                self.handle
+                    .increment_errors_total(Operation::Scan, e.kind());
             })
             .await
     }
@@ -867,6 +914,24 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         result.map_err(|e| {
             self.handle
                 .increment_errors_total(Operation::BlockingList, e.kind());
+            e
+        })
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        self.handle.requests_total_blocking_scan.increment(1);
+
+        let start = Instant::now();
+        let result = self.inner.blocking_scan(path, args);
+        let dur = start.elapsed().as_secs_f64();
+
+        self.handle
+            .requests_duration_seconds_blocking_scan
+            .record(dur);
+
+        result.map_err(|e| {
+            self.handle
+                .increment_errors_total(Operation::BlockingScan, e.kind());
             e
         })
     }

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -820,7 +820,7 @@ mod tests {
         fn metadata(&self) -> AccessorMetadata {
             let mut am = AccessorMetadata::default();
             am.set_capabilities(AccessorCapability::List);
-            am.set_hints(AccessorHint::ReadStreamable | AccessorHint::ListHierarchy);
+            am.set_hints(AccessorHint::ReadStreamable);
 
             am
         }

--- a/src/layers/retry.rs
+++ b/src/layers/retry.rs
@@ -238,6 +238,26 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
             .await
     }
 
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        { || self.inner.scan(path, args.clone()) }
+            .retry(&self.builder)
+            .when(|e| e.is_temporary())
+            .notify(|err, dur| {
+                warn!(
+                    target: "opendal::service",
+                    "operation={} -> retry after {}s: error={:?}",
+                    Operation::Scan, dur.as_secs_f64(), err)
+            })
+            .map(|v| {
+                v.map(|(l, p)| {
+                    let pager = RetryPager::new(p, path, self.builder.clone());
+                    (l, pager)
+                })
+                .map_err(|e| e.set_persistent())
+            })
+            .await
+    }
+
     async fn create_multipart(
         &self,
         path: &str,
@@ -377,6 +397,24 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
                     target: "opendal::service",
                     "operation={} -> retry after {}s: error={:?}",
                     Operation::BlockingList, dur.as_secs_f64(), err)
+            })
+            .call()
+            .map(|(rp, p)| {
+                let p = RetryPager::new(p, path, self.builder.clone());
+                (rp, p)
+            })
+            .map_err(|e| e.set_persistent())
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        { || self.inner.blocking_scan(path, args.clone()) }
+            .retry(&self.builder)
+            .when(|e| e.is_temporary())
+            .notify(|err, dur| {
+                warn!(
+                    target: "opendal::service",
+                    "operation={} -> retry after {}s: error={:?}",
+                    Operation::BlockingScan, dur.as_secs_f64(), err)
             })
             .call()
             .map(|(rp, p)| {

--- a/src/layers/tracing.rs
+++ b/src/layers/tracing.rs
@@ -186,6 +186,14 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.inner
+            .scan(path, args)
+            .map(|v| v.map(|(rp, s)| (rp, TracingWrapper::new(Span::current(), s))))
+            .await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args)
     }
@@ -264,6 +272,13 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner
             .blocking_list(path, args)
+            .map(|(rp, it)| (rp, TracingWrapper::new(Span::current(), it)))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        self.inner
+            .blocking_scan(path, args)
             .map(|(rp, it)| (rp, TracingWrapper::new(Span::current(), it)))
     }
 }

--- a/src/layers/type_eraser.rs
+++ b/src/layers/type_eraser.rs
@@ -80,4 +80,17 @@ impl<A: Accessor> LayeredAccessor for TypeEraseAccessor<A> {
             .blocking_list(path, args)
             .map(|(rp, p)| (rp, Box::new(p) as output::BlockingPager))
     }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.inner
+            .scan(path, args)
+            .await
+            .map(|(rp, p)| (rp, Box::new(p) as output::Pager))
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        self.inner
+            .blocking_scan(path, args)
+            .map(|(rp, p)| (rp, Box::new(p) as output::BlockingPager))
+    }
 }

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -1011,10 +1011,7 @@ impl Object {
             .with_context("path", self.path()));
         }
 
-        let (_, pager) = self
-            .acc
-            .list(self.path(), OpList::new(ListStyle::Hierarchy))
-            .await?;
+        let (_, pager) = self.acc.list(self.path(), OpList::new()).await?;
 
         Ok(ObjectLister::new(self.acc.clone(), pager))
     }
@@ -1061,9 +1058,7 @@ impl Object {
             .with_context("path", self.path()));
         }
 
-        let (_, pager) = self
-            .acc
-            .blocking_list(self.path(), OpList::new(ListStyle::Hierarchy))?;
+        let (_, pager) = self.acc.blocking_list(self.path(), OpList::new())?;
         Ok(BlockingObjectLister::new(self.acc.clone(), pager))
     }
 
@@ -1111,10 +1106,7 @@ impl Object {
             .with_context("path", self.path()));
         }
 
-        let (_, pager) = self
-            .acc
-            .list(self.path(), OpList::new(ListStyle::Flat))
-            .await?;
+        let (_, pager) = self.acc.scan(self.path(), OpScan::new()).await?;
 
         Ok(ObjectLister::new(self.acc.clone(), pager))
     }
@@ -1156,14 +1148,12 @@ impl Object {
                 ErrorKind::ObjectNotADirectory,
                 "the path trying to list is not a directory",
             )
-            .with_operation("Object::blocking_list")
+            .with_operation("Object::blocking_scan")
             .with_context("service", self.accessor().metadata().scheme().into_static())
             .with_context("path", self.path()));
         }
 
-        let (_, pager) = self
-            .acc
-            .blocking_list(self.path(), OpList::new(ListStyle::Flat))?;
+        let (_, pager) = self.acc.blocking_scan(self.path(), OpScan::new())?;
         Ok(BlockingObjectLister::new(self.acc.clone(), pager))
     }
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -96,6 +96,32 @@ pub enum ListStyle {
     Hierarchy,
 }
 
+/// Args for `scan` operation.
+#[derive(Debug, Default, Clone)]
+pub struct OpScan {
+    /// The limit passed to underlying service to specify the max results
+    /// that could return.
+    limit: Option<usize>,
+}
+
+impl OpScan {
+    /// Create a new `OpList`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Change the limit of this list operation.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Get the limit of list operation.
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+}
+
 /// Args for `create_multipart` operation.
 #[derive(Debug, Clone, Default)]
 pub struct OpCreateMultipart {}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -55,10 +55,8 @@ impl OpDelete {
 }
 
 /// Args for `list` operation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OpList {
-    /// The style passed to underlying services to specify the list style.
-    style: ListStyle,
     /// The limit passed to underlying service to specify the max results
     /// that could return.
     limit: Option<usize>,
@@ -66,13 +64,8 @@ pub struct OpList {
 
 impl OpList {
     /// Create a new `OpList`.
-    pub fn new(style: ListStyle) -> Self {
-        Self { style, limit: None }
-    }
-
-    /// Get the style from list.
-    pub fn style(&self) -> ListStyle {
-        self.style
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Change the limit of this list operation.

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -581,6 +581,8 @@ flags! {
         Write,
         /// Add this capability if service supports `list`
         List,
+        /// Add this capability if service supports `scan`
+        Scan,
         /// Add this capability if service supports `presign`
         Presign,
         /// Add this capability if service supports `multipart`
@@ -605,9 +607,5 @@ flags! {
         ///
         /// It's better to use stream to reading data.
         ReadStreamable,
-        /// List flat means this underlying can list with flat style.
-        ListFlat,
-        /// List hierarchy means this underlying can list with hierarchy style.
-        ListHierarchy,
     }
 }

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -174,6 +174,16 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
         ))
     }
 
+    /// Invoke the `scan` operation on the specified path.
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        let (_, _) = (path, args);
+
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "operation is not supported",
+        ))
+    }
+
     /// Invoke the `presign` operation on the specified path.
     ///
     /// # Behavior
@@ -364,6 +374,16 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
             "operation is not supported",
         ))
     }
+
+    /// Invoke the `blocking_scan` operation on the specified path.
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        let (_, _) = (path, args);
+
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "operation is not supported",
+        ))
+    }
 }
 
 /// All functions in `Accessor` only requires `&self`, so it's safe to implement
@@ -397,6 +417,9 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
     }
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         self.as_ref().list(path, args).await
+    }
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.as_ref().scan(path, args).await
     }
 
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
@@ -455,6 +478,10 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
     }
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.as_ref().blocking_list(path, args)
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.as_ref().blocking_scan(path, args)
     }
 }
 

--- a/src/raw/accessor.rs
+++ b/src/raw/accessor.rs
@@ -376,7 +376,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     }
 
     /// Invoke the `blocking_scan` operation on the specified path.
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
         let (_, _) = (path, args);
 
         Err(Error::new(
@@ -480,7 +480,7 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().blocking_list(path, args)
     }
 
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
         self.as_ref().blocking_scan(path, args)
     }
 }

--- a/src/raw/io/output/into_reader/by_range.rs
+++ b/src/raw/io/output/into_reader/by_range.rs
@@ -320,6 +320,13 @@ mod tests {
         type Pager = ();
         type BlockingPager = ();
 
+        fn metadata(&self) -> AccessorMetadata {
+            let mut am = AccessorMetadata::default();
+            am.set_capabilities(AccessorCapability::Read);
+
+            am
+        }
+
         async fn read(&self, _: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
             let bs = args.range().apply_on_bytes(self.data.clone());
 

--- a/src/raw/io/output/page.rs
+++ b/src/raw/io/output/page.rs
@@ -17,10 +17,8 @@ use async_trait::async_trait;
 use super::Entry;
 use crate::*;
 
-/// Page trait is used by [`Accessor`] to implement `list` operation.
-///
-/// `list` will return a boxed `Page` which allow users to call `next_page`
-/// to fecth a new page of [`Entry`].
+/// Page trait is used by [`crate::raw::Accessor`] to implement `list`
+/// or `scan` operation.
 #[async_trait]
 pub trait Page: Send + Sync + 'static {
     /// Fetch a new page of [`Entry`]

--- a/src/raw/layer.rs
+++ b/src/raw/layer.rs
@@ -144,6 +144,8 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)>;
 
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)>;
+
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner().presign(path, args)
     }
@@ -205,6 +207,8 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)>;
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)>;
 }
 
 #[async_trait]
@@ -240,6 +244,10 @@ impl<L: LayeredAccessor> Accessor for L {
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         (self as &L).list(path, args).await
+    }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        (self as &L).scan(path, args).await
     }
 
     fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
@@ -306,6 +314,10 @@ impl<L: LayeredAccessor> Accessor for L {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         (self as &L).blocking_list(path, args)
+    }
+
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        (self as &L).blocking_scan(path, args)
     }
 }
 

--- a/src/raw/layer.rs
+++ b/src/raw/layer.rs
@@ -84,6 +84,14 @@ use crate::*;
 ///     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
 ///         self.inner.blocking_list(path, args)
 ///     }
+///
+///     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+///         self.inner.scan(path, args).await
+///     }
+///
+///     fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+///         self.inner.blocking_scan(path, args)
+///     }
 /// }
 ///
 /// /// The public struct that exposed to users.

--- a/src/raw/operation.rs
+++ b/src/raw/operation.rs
@@ -33,6 +33,8 @@ pub enum Operation {
     Delete,
     /// Operation for [`crate::raw::Accessor::list`]
     List,
+    /// Operation for [`crate::raw::Accessor::Scan`]
+    Scan,
     /// Operation for [`crate::raw::Accessor::presign`]
     Presign,
     /// Operation for [`crate::raw::Accessor::create_multipart`]
@@ -55,6 +57,8 @@ pub enum Operation {
     BlockingDelete,
     /// Operation for [`crate::raw::Accessor::blocking_list`]
     BlockingList,
+    /// Operation for [`crate::raw::Accessor::blocking_scan`]
+    BlockingScan,
 }
 
 impl Operation {
@@ -86,6 +90,7 @@ impl From<Operation> for &'static str {
             Operation::Stat => "stat",
             Operation::Delete => "delete",
             Operation::List => "list",
+            Operation::Scan => "scan",
             Operation::Presign => "presign",
             Operation::CreateMultipart => "create_multipart",
             Operation::WriteMultipart => "write_multipart",
@@ -97,6 +102,7 @@ impl From<Operation> for &'static str {
             Operation::BlockingStat => "blocking_stat",
             Operation::BlockingDelete => "blocking_delete",
             Operation::BlockingList => "blocking_list",
+            Operation::BlockingScan => "blocking_scan",
         }
     }
 }

--- a/src/raw/operation.rs
+++ b/src/raw/operation.rs
@@ -33,7 +33,7 @@ pub enum Operation {
     Delete,
     /// Operation for [`crate::raw::Accessor::list`]
     List,
-    /// Operation for [`crate::raw::Accessor::Scan`]
+    /// Operation for [`crate::raw::Accessor::scan`]
     Scan,
     /// Operation for [`crate::raw::Accessor::presign`]
     Presign,

--- a/src/raw/rps.rs
+++ b/src/raw/rps.rs
@@ -28,6 +28,10 @@ pub struct RpDelete {}
 #[derive(Debug, Clone, Default)]
 pub struct RpList {}
 
+/// Reply for `scan` operation.
+#[derive(Debug, Clone, Default)]
+pub struct RpScan {}
+
 /// Reply for `create_multipart` operation.
 #[derive(Debug, Clone, Default)]
 pub struct RpCreateMultipart {

--- a/src/services/azdfs/backend.rs
+++ b/src/services/azdfs/backend.rs
@@ -311,7 +311,7 @@ impl Accessor for AzdfsBackend {
             .set_capabilities(
                 AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
             )
-            .set_hints(AccessorHint::ReadStreamable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadStreamable);
 
         am
     }
@@ -423,13 +423,6 @@ impl Accessor for AzdfsBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let op = DirStream::new(
             Arc::new(self.clone()),
             self.root.clone(),

--- a/src/services/fs/backend.rs
+++ b/src/services/fs/backend.rs
@@ -304,7 +304,7 @@ impl Accessor for FsBackend {
                     | AccessorCapability::List
                     | AccessorCapability::Blocking,
             )
-            .set_hints(AccessorHint::ReadSeekable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadSeekable);
 
         am
     }
@@ -511,13 +511,6 @@ impl Accessor for FsBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let p = self.root.join(path.trim_end_matches('/'));
 
         let f = match tokio::fs::read_dir(&p).await {
@@ -722,13 +715,6 @@ impl Accessor for FsBackend {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let p = self.root.join(path.trim_end_matches('/'));
 
         let f = match std::fs::read_dir(p) {

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -321,8 +321,7 @@ impl Accessor for FtpBackend {
             .set_root(&self.root)
             .set_capabilities(
                 AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            )
-            .set_hints(AccessorHint::ListHierarchy);
+            );
 
         am
     }
@@ -451,13 +450,6 @@ impl Accessor for FtpBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let mut ftp_stream = self.ftp_connect(Operation::List).await?;
 
         let pathname = if path == "/" { None } else { Some(path) };

--- a/src/services/gcs/backend.rs
+++ b/src/services/gcs/backend.rs
@@ -350,16 +350,15 @@ impl Accessor for GcsBackend {
     type BlockingPager = ();
 
     fn metadata(&self) -> AccessorMetadata {
+        use AccessorCapability::*;
+        use AccessorHint::*;
+
         let mut am = AccessorMetadata::default();
         am.set_scheme(Scheme::Gcs)
             .set_root(&self.root)
             .set_name(&self.bucket)
-            .set_capabilities(
-                AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            )
-            .set_hints(
-                AccessorHint::ReadStreamable | AccessorHint::ListFlat | AccessorHint::ListHierarchy,
-            );
+            .set_capabilities(Read | Write | List | Scan)
+            .set_hints(ReadStreamable);
         am
     }
 
@@ -467,20 +466,16 @@ impl Accessor for GcsBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        let delimiter = match args.style() {
-            ListStyle::Flat => "",
-            ListStyle::Hierarchy => "/",
-        };
-
         Ok((
             RpList::default(),
-            DirStream::new(
-                Arc::new(self.clone()),
-                &self.root,
-                path,
-                delimiter,
-                args.limit(),
-            ),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "/", args.limit()),
+        ))
+    }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        Ok((
+            RpScan::default(),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "", args.limit()),
         ))
     }
 }

--- a/src/services/hdfs/backend.rs
+++ b/src/services/hdfs/backend.rs
@@ -235,7 +235,7 @@ impl Accessor for HdfsBackend {
                     | AccessorCapability::List
                     | AccessorCapability::Blocking,
             )
-            .set_hints(AccessorHint::ReadSeekable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadSeekable);
 
         am
     }
@@ -393,13 +393,6 @@ impl Accessor for HdfsBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let p = build_rooted_abs_path(&self.root, path);
 
         let f = match self.client.read_dir(&p) {
@@ -574,13 +567,6 @@ impl Accessor for HdfsBackend {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
         let p = build_rooted_abs_path(&self.root, path);
 
         let f = match self.client.read_dir(&p) {

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -217,7 +217,7 @@ impl Accessor for IpfsBackend {
         ma.set_scheme(Scheme::Ipfs)
             .set_root(&self.root)
             .set_capabilities(AccessorCapability::Read | AccessorCapability::List)
-            .set_hints(AccessorHint::ReadStreamable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadStreamable);
 
         ma
     }
@@ -383,14 +383,7 @@ impl Accessor for IpfsBackend {
         }
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
+    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
         Ok((
             RpList::default(),
             DirStream::new(Arc::new(self.clone()), path),

--- a/src/services/ipmfs/backend.rs
+++ b/src/services/ipmfs/backend.rs
@@ -71,7 +71,7 @@ impl Accessor for IpmfsBackend {
             .set_capabilities(
                 AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
             )
-            .set_hints(AccessorHint::ReadStreamable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadStreamable);
 
         am
     }
@@ -170,14 +170,7 @@ impl Accessor for IpmfsBackend {
         }
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
+    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
         Ok((
             RpList::default(),
             DirStream::new(Arc::new(self.clone()), &self.root, path),

--- a/src/services/obs/backend.rs
+++ b/src/services/obs/backend.rs
@@ -307,16 +307,15 @@ impl Accessor for ObsBackend {
     type BlockingPager = ();
 
     fn metadata(&self) -> AccessorMetadata {
+        use AccessorCapability::*;
+        use AccessorHint::*;
+
         let mut am = AccessorMetadata::default();
         am.set_scheme(Scheme::Obs)
             .set_root(&self.root)
             .set_name(&self.bucket)
-            .set_capabilities(
-                AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            )
-            .set_hints(
-                AccessorHint::ReadStreamable | AccessorHint::ListFlat | AccessorHint::ListHierarchy,
-            );
+            .set_capabilities(Read | Write | List | Scan)
+            .set_hints(ReadStreamable);
 
         am
     }
@@ -410,20 +409,16 @@ impl Accessor for ObsBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        let delimiter = match args.style() {
-            ListStyle::Flat => "",
-            ListStyle::Hierarchy => "/",
-        };
-
         Ok((
             RpList::default(),
-            DirStream::new(
-                Arc::new(self.clone()),
-                &self.root,
-                path,
-                delimiter,
-                args.limit(),
-            ),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "", args.limit()),
+        ))
+    }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        Ok((
+            RpScan::default(),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "", args.limit()),
         ))
     }
 }

--- a/src/services/obs/backend.rs
+++ b/src/services/obs/backend.rs
@@ -411,7 +411,7 @@ impl Accessor for ObsBackend {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         Ok((
             RpList::default(),
-            DirStream::new(Arc::new(self.clone()), &self.root, path, "", args.limit()),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "/", args.limit()),
         ))
     }
 

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -1111,20 +1111,15 @@ impl Accessor for S3Backend {
     type BlockingPager = ();
 
     fn metadata(&self) -> AccessorMetadata {
+        use AccessorCapability::*;
+        use AccessorHint::*;
+
         let mut am = AccessorMetadata::default();
         am.set_scheme(Scheme::S3)
             .set_root(&self.root)
             .set_name(&self.bucket)
-            .set_capabilities(
-                AccessorCapability::Read
-                    | AccessorCapability::Write
-                    | AccessorCapability::List
-                    | AccessorCapability::Presign
-                    | AccessorCapability::Multipart,
-            )
-            .set_hints(
-                AccessorHint::ReadStreamable | AccessorHint::ListFlat | AccessorHint::ListHierarchy,
-            );
+            .set_capabilities(Read | Write | List | Scan | Presign | Multipart)
+            .set_hints(ReadStreamable);
 
         am
     }
@@ -1215,20 +1210,16 @@ impl Accessor for S3Backend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        let delimiter = match args.style() {
-            ListStyle::Flat => "",
-            ListStyle::Hierarchy => "/",
-        };
-
         Ok((
             RpList::default(),
-            DirStream::new(
-                Arc::new(self.clone()),
-                &self.root,
-                path,
-                delimiter,
-                args.limit(),
-            ),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "/", args.limit()),
+        ))
+    }
+
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        Ok((
+            RpScan::default(),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "/", args.limit()),
         ))
     }
 

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -1219,7 +1219,7 @@ impl Accessor for S3Backend {
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
         Ok((
             RpScan::default(),
-            DirStream::new(Arc::new(self.clone()), &self.root, path, "/", args.limit()),
+            DirStream::new(Arc::new(self.clone()), &self.root, path, "", args.limit()),
         ))
     }
 

--- a/src/services/sled/backend.rs
+++ b/src/services/sled/backend.rs
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    raw::{adapters::kv, *},
-    Builder, Error, ErrorKind, Scheme, *,
-};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
 use async_trait::async_trait;
-use std::{
-    collections::HashMap,
-    fmt::{Debug, Formatter},
-};
+
+use crate::raw::adapters::kv;
+use crate::raw::*;
+use crate::Builder;
+use crate::Error;
+use crate::ErrorKind;
+use crate::Scheme;
+use crate::*;
 
 /// Sled service support.
 ///

--- a/src/services/webhdfs/backend.rs
+++ b/src/services/webhdfs/backend.rs
@@ -547,7 +547,7 @@ impl Accessor for WebhdfsBackend {
             .set_capabilities(
                 AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
             )
-            .set_hints(AccessorHint::ReadStreamable | AccessorHint::ListHierarchy);
+            .set_hints(AccessorHint::ReadStreamable);
         am
     }
 
@@ -675,14 +675,7 @@ impl Accessor for WebhdfsBackend {
         }
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        if !matches!(args.style(), ListStyle::Hierarchy) {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "list with flat style is not supported",
-            ));
-        }
-
+    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
         let path = path.trim_end_matches('/');
         let req = self.webhdfs_list_status_req(path)?;
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Extract scan as a new API and remove ListStyle
