### PR TITLE
ci: Add test case for webdav with basic auth

### DIFF
--- a/.github/workflows/service_test_webdav.yml
+++ b/.github/workflows/service_test_webdav.yml
@@ -38,3 +38,40 @@ jobs:
           RUST_LOG: debug
           OPENDAL_WEBDAV_TEST: on
           OPENDAL_WEBDAV_ENDPOINT: http://127.0.0.1:8080
+
+  nginx_with_password:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start nginx
+        shell: bash
+        run: |
+          mkdir -p /tmp/static
+          cp `pwd`/src/services/webdav/fixtures/htpasswd /tmp/htpasswd
+          nginx -c `pwd`/src/services/webdav/fixtures/nginx-with-basic-auth.conf
+
+      - name: Test empty password
+        shell: bash
+        run: cargo test webdav --features compress -- --show-output
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: debug
+          OPENDAL_WEBDAV_TEST: on
+          OPENDAL_WEBDAV_ENDPOINT: http://127.0.0.1:8080
+          OPENDAL_WEBDAV_USERNAME: foo
+
+      - name: Test with password
+        shell: bash
+        run: cargo test webdav --features compress -- --show-output
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: debug
+          OPENDAL_WEBDAV_TEST: on
+          OPENDAL_WEBDAV_ENDPOINT: http://127.0.0.1:8080
+          OPENDAL_WEBDAV_USERNAME: bar
+          OPENDAL_WEBDAV_PASSWORD: bar

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -18,6 +18,7 @@ header:
     - "**/*.toml"
     - "**/*.lock"
     - "**/*.tldr"
+    - "**/fixtures/**"
     - "target/**"
     - "**/target/**"
     # Ignore test data

--- a/src/services/webdav/fixtures/htpasswd
+++ b/src/services/webdav/fixtures/htpasswd
@@ -1,0 +1,2 @@
+foo:$2y$10$GxAX8rC4qDTymm1AxocMmeWIT3ILwGg8Bk.U.SdMVbk7.iH5Cvf9y
+bar:$2y$10$lNipq5OoOCIoFphWtGsTD./Lw323C0bNBKaPjcR/deoS3OwxJD.qS

--- a/src/services/webdav/fixtures/nginx-with-basic-auth.conf
+++ b/src/services/webdav/fixtures/nginx-with-basic-auth.conf
@@ -1,17 +1,3 @@
-# Copyright 2022 Datafuse Labs.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 error_log /tmp/error.log;
 pid       /tmp/nginx.pid;
 
@@ -27,6 +13,11 @@ http {
     root         /tmp/static;
 
     location / {
+      client_body_temp_path /tmp;
+      log_not_found off;
+      dav_methods PUT DELETE;
+      create_full_put_path on;
+      client_max_body_size 1024M;
       auth_basic           "Administrator’s Area";
       auth_basic_user_file /etc/apache2/.htpasswd;
     }

--- a/src/services/webdav/fixtures/nginx-with-basic-auth.conf
+++ b/src/services/webdav/fixtures/nginx-with-basic-auth.conf
@@ -19,7 +19,7 @@ http {
       create_full_put_path on;
       client_max_body_size 1024M;
       auth_basic           "Administrator’s Area";
-      auth_basic_user_file /etc/apache2/.htpasswd;
+      auth_basic_user_file /tmp/htpasswd;
     }
   }
 }

--- a/src/services/webdav/fixtures/nginx-with-basic-auth.conf
+++ b/src/services/webdav/fixtures/nginx-with-basic-auth.conf
@@ -1,0 +1,34 @@
+# Copyright 2022 Datafuse Labs.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+error_log /tmp/error.log;
+pid       /tmp/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen       127.0.0.1:8080;
+    server_name  localhost;
+    access_log   /tmp/access.log;
+    root         /tmp/static;
+
+    location / {
+      auth_basic           "Administrator’s Area";
+      auth_basic_user_file /etc/apache2/.htpasswd;
+    }
+  }
+}

--- a/src/services/webdav/fixtures/nginx.conf
+++ b/src/services/webdav/fixtures/nginx.conf
@@ -1,17 +1,3 @@
-# Copyright 2022 Datafuse Labs.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 error_log /tmp/error.log;
 pid       /tmp/nginx.pid;
 


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Add test case for webdav with basic auth