### PR TITLE
fix(services/oss,s3): Metadata should be marked as complete

### DIFF
--- a/src/services/oss/dir_stream.rs
+++ b/src/services/oss/dir_stream.rs
@@ -107,7 +107,7 @@ impl output::Page for DirStream {
             if object.key.ends_with('/') {
                 continue;
             }
-            let mut meta = ObjectMetadata::new(ObjectMode::FILE);
+            let mut meta = ObjectMetadata::new(ObjectMode::FILE).with_complete();
 
             meta.set_etag(&object.etag);
             meta.set_content_length(object.size);

--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -116,7 +116,7 @@ impl output::Page for DirStream {
                 continue;
             }
 
-            let mut meta = ObjectMetadata::new(ObjectMode::FILE);
+            let mut meta = ObjectMetadata::new(ObjectMode::FILE).with_complete();
 
             meta.set_etag(&object.etag);
             meta.set_content_md5(object.etag.trim_matches('"'));


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

fix(services/{oss,s3}): Metadata should be marked as complete
