### PR TITLE
feat: add Content-Disposition for inner API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,9 @@ mod tests {
         assert_eq!(88, size_of::<AccessorMetadata>());
         assert_eq!(16, size_of::<Operator>());
         assert_eq!(16, size_of::<BatchOperator>());
-        assert_eq!(184, size_of::<output::Entry>());
+        assert_eq!(208, size_of::<output::Entry>());
         assert_eq!(48, size_of::<Object>());
-        assert_eq!(160, size_of::<ObjectMetadata>());
+        assert_eq!(184, size_of::<ObjectMetadata>());
         assert_eq!(1, size_of::<ObjectMode>());
         assert_eq!(64, size_of::<ObjectMultipart>());
         assert_eq!(32, size_of::<ObjectPart>());

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -50,6 +50,8 @@ pub struct ObjectMetadata {
     last_modified: Option<OffsetDateTime>,
     /// ETag of this object.
     etag: Option<String>,
+    /// Content-Disposition of this object
+    content_disposition: Option<String>,
 }
 
 impl ObjectMetadata {
@@ -66,6 +68,7 @@ impl ObjectMetadata {
             content_range: None,
             last_modified: None,
             etag: None,
+            content_disposition: None,
         }
     }
 
@@ -274,6 +277,53 @@ impl ObjectMetadata {
     /// `"` is part of etag, don't trim it before setting.
     pub fn with_etag(mut self, etag: &str) -> Self {
         self.etag = Some(etag.to_string());
+        self
+    }
+
+    /// Content-Disposition of this object
+    ///
+    /// `Content-Disposition` is defined by [RFC 2616](https://www.rfc-editor/rfcs/2616) and
+    /// clarified usage in [RFC 6266](https://www.rfc-editor/6266).
+    /// Refer to [MDN Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) for more information.
+    ///
+    /// OpenDAL will return this value AS-IS like the following:
+    ///
+    /// - "inline"
+    /// - "attachment"
+    /// - "attachment; filename=\"filename.jpg\""
+    pub fn content_disposition(&self) -> Option<&str> {
+        self.content_disposition.as_deref()
+    }
+
+    /// Set Content-Disposition of this object
+    ///
+    /// `Content-Disposition` is defined by [RFC 2616](https://www.rfc-editor/rfcs/2616) and
+    /// clarified usage in [RFC 6266](https://www.rfc-editor/6266).
+    /// Refer to [MDN Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) for more information.
+    ///
+    /// OpenDAL will return this value AS-IS like the following:
+    ///
+    /// - "inline"
+    /// - "attachment"
+    /// - "attachment; filename=\"filename.jpg\""
+    pub fn with_content_disposition(mut self, content_disposition: &str) -> Self {
+        self.content_disposition = Some(content_disposition.to_string());
+        self
+    }
+
+    /// Set Content-Disposition of this object
+    ///
+    /// `Content-Disposition` is defined by [RFC 2616](https://www.rfc-editor/rfcs/2616) and
+    /// clarified usage in [RFC 6266](https://www.rfc-editor/6266).
+    /// Refer to [MDN Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) for more information.
+    ///
+    /// OpenDAL will return this value AS-IS like the following:
+    ///
+    /// - "inline"
+    /// - "attachment"
+    /// - "attachment; filename=\"filename.jpg\""
+    pub fn set_content_disposition(&mut self, content_disposition: &str) -> &mut Self {
+        self.content_disposition = Some(content_disposition.to_string());
         self
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -330,6 +330,7 @@ impl OpStat {
 pub struct OpWrite {
     size: u64,
     content_type: Option<String>,
+    content_disposition: Option<String>,
 }
 
 impl OpWrite {
@@ -340,6 +341,7 @@ impl OpWrite {
         Self {
             size,
             content_type: None,
+            content_disposition: None,
         }
     }
 
@@ -348,6 +350,16 @@ impl OpWrite {
         Self {
             size: self.size(),
             content_type: Some(content_type.to_string()),
+            content_disposition: self.content_disposition,
+        }
+    }
+
+    /// Set the content disposition of option
+    pub fn with_content_disposition(self, content_disposition: &str) -> Self {
+        Self {
+            size: self.size(),
+            content_type: self.content_type,
+            content_disposition: Some(content_disposition.to_string()),
         }
     }
 
@@ -358,5 +370,10 @@ impl OpWrite {
     /// Get the content type from option
     pub fn content_type(&self) -> Option<&str> {
         self.content_type.as_deref()
+    }
+
+    /// Get the content disposition from option
+    pub fn content_disposition(&self) -> Option<&str> {
+        self.content_disposition.as_deref()
     }
 }


### PR DESCRIPTION
1. add Content-Disposition support for ObjectMetadata
2. add Content-Disposition support for OpWrite

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/
