### PR TITLE
refactor: Authorization logic for WebdavBackend

### DIFF
--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -401,9 +401,9 @@ impl WebdavBackend {
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
         let mut req = if self.authorization.is_empty() {
-            Request::get(&url)
+            Request::put(&url)
         } else {
-            Request::get(&url).header(AUTHORIZATION, &self.authorization)
+            Request::put(&url).header(AUTHORIZATION, &self.authorization)
         };
 
         if let Some(size) = size {
@@ -426,9 +426,9 @@ impl WebdavBackend {
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
         let req = if self.authorization.is_empty() {
-            Request::get(&url)
+            Request::head(&url)
         } else {
-            Request::get(&url).header(AUTHORIZATION, &self.authorization)
+            Request::head(&url).header(AUTHORIZATION, &self.authorization)
         };
 
         let req = req

--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -99,8 +99,6 @@ impl Debug for WebdavBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut de = f.debug_struct("Builder");
         de.field("endpoint", &self.endpoint);
-        de.field("username", &self.username);
-        de.field("password", &self.password);
         de.field("root", &self.root);
 
         de.finish()
@@ -249,7 +247,6 @@ impl Debug for WebdavBackend {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Backend")
             .field("endpoint", &self.endpoint)
-            .field("authorization", &self.authorization)
             .field("root", &self.root)
             .field("client", &self.client)
             .finish()

--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -99,6 +99,8 @@ impl Debug for WebdavBuilder {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut de = f.debug_struct("Builder");
         de.field("endpoint", &self.endpoint);
+        de.field("username", &self.username);
+        de.field("password", &self.password);
         de.field("root", &self.root);
 
         de.finish()
@@ -247,6 +249,7 @@ impl Debug for WebdavBackend {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Backend")
             .field("endpoint", &self.endpoint)
+            .field("authorization", &self.authorization)
             .field("root", &self.root)
             .field("client", &self.client)
             .finish()

--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -369,7 +369,11 @@ impl WebdavBackend {
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
-        let mut req = Request::get(&url).header(AUTHORIZATION, &self.authorization);
+        let mut req = if self.authorization.is_empty() {
+            Request::get(&url)
+        } else {
+            Request::get(&url).header(AUTHORIZATION, &self.authorization)
+        };
 
         if !range.is_full() {
             req = req.header(http::header::RANGE, range.to_header());
@@ -393,7 +397,11 @@ impl WebdavBackend {
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
-        let mut req = Request::put(&url).header(AUTHORIZATION, &self.authorization);
+        let mut req = if self.authorization.is_empty() {
+            Request::get(&url)
+        } else {
+            Request::get(&url).header(AUTHORIZATION, &self.authorization)
+        };
 
         if let Some(size) = size {
             req = req.header(CONTENT_LENGTH, size)
@@ -414,7 +422,11 @@ impl WebdavBackend {
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
-        let req = Request::head(&url).header(AUTHORIZATION, &self.authorization);
+        let req = if self.authorization.is_empty() {
+            Request::get(&url)
+        } else {
+            Request::get(&url).header(AUTHORIZATION, &self.authorization)
+        };
 
         let req = req
             .body(AsyncBody::Empty)
@@ -428,10 +440,13 @@ impl WebdavBackend {
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
-        let req = Request::delete(&url)
-            .header(AUTHORIZATION, &self.authorization)
-            .body(AsyncBody::Empty)
-            .map_err(new_request_build_error)?;
+        let req = if self.authorization.is_empty() {
+            Request::delete(&url)
+        } else {
+            Request::delete(&url).header(AUTHORIZATION, &self.authorization)
+        }
+        .body(AsyncBody::Empty)
+        .map_err(new_request_build_error)?;
 
         self.client.send_async(req).await
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

if username and password aren't set, the http request needn't authorization

Summary about this PR
