### PR TITLE
feat: add content-disposition support for services

### DIFF
--- a/src/raw/http_util/mod.rs
+++ b/src/raw/http_util/mod.rs
@@ -28,6 +28,7 @@ pub use body::Body;
 pub use body::IncomingAsyncBody;
 
 mod header;
+pub use header::parse_content_disposition;
 pub use header::parse_content_length;
 pub use header::parse_content_md5;
 pub use header::parse_content_range;

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -375,6 +375,10 @@ impl Accessor for IpfsBackend {
                     m.set_mode(ObjectMode::DIR);
                 }
 
+                if let Some(v) = parse_content_disposition(resp.headers())? {
+                    m.set_content_disposition(v);
+                }
+
                 Ok(RpStat::new(m))
             }
             StatusCode::FOUND | StatusCode::MOVED_PERMANENTLY => {

--- a/src/services/s3/backend.rs
+++ b/src/services/s3/backend.rs
@@ -24,6 +24,7 @@ use base64::Engine;
 use bytes::Buf;
 use bytes::Bytes;
 use http::header::HeaderName;
+use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
@@ -1126,7 +1127,7 @@ impl Accessor for S3Backend {
     }
 
     async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
-        let mut req = self.s3_put_object_request(path, Some(0), None, AsyncBody::Empty)?;
+        let mut req = self.s3_put_object_request(path, Some(0), None, None, AsyncBody::Empty)?;
 
         self.signer.sign(&mut req).map_err(new_request_sign_error)?;
 
@@ -1162,6 +1163,7 @@ impl Accessor for S3Backend {
             path,
             Some(args.size()),
             args.content_type(),
+            args.content_disposition(),
             AsyncBody::Reader(r),
         )?;
 
@@ -1230,7 +1232,7 @@ impl Accessor for S3Backend {
             PresignOperation::Stat(_) => self.s3_head_object_request(path)?,
             PresignOperation::Read(v) => self.s3_get_object_request(path, v.range())?,
             PresignOperation::Write(_) => {
-                self.s3_put_object_request(path, None, None, AsyncBody::Empty)?
+                self.s3_put_object_request(path, None, None, None, AsyncBody::Empty)?
             }
             PresignOperation::WriteMultipart(v) => self.s3_upload_part_request(
                 path,
@@ -1415,6 +1417,7 @@ impl S3Backend {
         path: &str,
         size: Option<u64>,
         content_type: Option<&str>,
+        content_disposition: Option<&str>,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
@@ -1429,6 +1432,10 @@ impl S3Backend {
 
         if let Some(mime) = content_type {
             req = req.header(CONTENT_TYPE, mime)
+        }
+
+        if let Some(pos) = content_disposition {
+            req = req.header(CONTENT_DISPOSITION, pos)
         }
 
         // Set SSE headers.


### PR DESCRIPTION
added support for:

1. azdfs    write   stat
2. ipfs             stat
3. ali oss  write   stat
4. aws s3   write   stat
5. webdav   write   stat

for other services, if the HTTP response includes `Content-Disposition`, the ObjectMetadata will got it.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

solves: #1346 
