### PR TITLE
refactor(webhdfs): handle 307 redirection instead of noredirect

### DIFF
--- a/src/raw/http_util/header.rs
+++ b/src/raw/http_util/header.rs
@@ -19,6 +19,7 @@ use http::header::CONTENT_RANGE;
 use http::header::CONTENT_TYPE;
 use http::header::ETAG;
 use http::header::LAST_MODIFIED;
+use http::header::LOCATION;
 use http::HeaderMap;
 use time::format_description::well_known::Rfc2822;
 use time::OffsetDateTime;
@@ -29,6 +30,24 @@ use crate::ErrorKind;
 use crate::ObjectMetadata;
 use crate::ObjectMode;
 use crate::Result;
+
+/// Parse redirect location from header map
+///
+/// # Note
+/// The returned value maybe a relative path, like `/index.html`, `/robots.txt`, etc.
+pub fn parse_location(headers: &HeaderMap) -> Result<Option<&str>> {
+    match headers.get(LOCATION) {
+        None => Ok(None),
+        Some(v) => Ok(Some(v.to_str().map_err(|e| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "header value has to be valid utf-8 string",
+            )
+            .with_operation("http_util::parse_location")
+            .set_source(e)
+        })?)),
+    }
+}
 
 /// Parse content length from header map.
 pub fn parse_content_length(headers: &HeaderMap) -> Result<Option<u64>> {

--- a/src/raw/http_util/mod.rs
+++ b/src/raw/http_util/mod.rs
@@ -36,6 +36,7 @@ pub use header::parse_content_type;
 pub use header::parse_etag;
 pub use header::parse_into_object_metadata;
 pub use header::parse_last_modified;
+pub use header::parse_location;
 
 mod uri;
 pub use uri::percent_encode_path;

--- a/src/services/webhdfs/backend.rs
+++ b/src/services/webhdfs/backend.rs
@@ -285,11 +285,7 @@ impl WebhdfsBackend {
 
         // should be a 307 TEMPORARY_REDIRECT
         if resp.status() != StatusCode::TEMPORARY_REDIRECT {
-            let err = Error::new(
-                ErrorKind::Unexpected,
-                &format!("expected 307 temporary redirect, got {}", resp.status()),
-            );
-            return Err(err);
+            return Err(parse_error(resp).await?);
         }
         let re_url = self.follow_redirect(resp)?;
 
@@ -390,11 +386,7 @@ impl WebhdfsBackend {
 
         // this should be a 307 redirect
         if resp.status() != StatusCode::TEMPORARY_REDIRECT {
-            let err = Error::new(
-                ErrorKind::Unexpected,
-                &format!("expected 307 temporary redirect, got {}", resp.status()),
-            );
-            return Err(err);
+            return Err(parse_error(resp).await?);
         }
 
         let re_url = self.follow_redirect(resp)?;

--- a/src/services/webhdfs/message.rs
+++ b/src/services/webhdfs/message.rs
@@ -19,12 +19,6 @@ use serde::Deserialize;
 use crate::*;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub(super) struct Redirection {
-    pub location: String,
-}
-
-#[derive(Debug, Deserialize)]
 pub(super) struct BooleanResp {
     pub boolean: bool,
 }
@@ -88,16 +82,6 @@ mod test {
     use crate::raw::output::Page;
     use crate::services::webhdfs::dir_stream::DirStream;
     use crate::ObjectMode;
-
-    #[test]
-    fn test_file_statuses() {
-        let json = r#"{"Location":"http://<DATANODE>:<PORT>/webhdfs/v1/<PATH>?op=CREATE..."}"#;
-        let redir: Redirection = serde_json::from_str(json).expect("must success");
-        assert_eq!(
-            redir.location,
-            "http://<DATANODE>:<PORT>/webhdfs/v1/<PATH>?op=CREATE..."
-        );
-    }
 
     #[test]
     fn test_file_status() {


### PR DESCRIPTION
OpenDAL will handle all redirections, and auto redirection of client is not taken into considerations. So for WebHDFS, handler redirections directly instead of `noredirect=true`. This also offers better compatibility.

I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

fixes: #1355
