### PR TITLE
feat: support auth for HttpBackend

### DIFF
--- a/src/services/webdav/backend.rs
+++ b/src/services/webdav/backend.rs
@@ -215,7 +215,7 @@ impl Builder for WebdavBuilder {
             })?
         };
 
-        // base64 encode
+        // authorization via `Basic` or `Bearer`
         let auth = match (&self.username, &self.password, &self.token) {
             (Some(username), Some(password), None) => {
                 format!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add Basic and Bearer authorization support for `HttpBackend`
#1237
