### PR TITLE
ci: Pin time <= 0.3.17 until we decide to bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ suppaftp = { version = "4.5", default-features = false, features = [
 ], optional = true }
 # time 0.3.18 bump MSRV to 1.62, let's pin to 0.3.17 until we decide
 # to bump ours
-time = { version = "<=0.3.17", features = ["serde"] }
+time = { version = ">=0.3.10, <=0.3.17", features = ["serde"] }
 tokio = { version = "1.20", features = ["fs"] }
 tracing = { version = "0.1", optional = true }
 trust-dns-resolver = { version = "0.22", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,9 @@ suppaftp = { version = "4.5", default-features = false, features = [
   "async-secure",
   "async-rustls",
 ], optional = true }
-time = { version = "0.3.10", features = ["serde"] }
+# time 0.3.18 bump MSRV to 1.62, let's pin to 0.3.17 until we decide
+# to bump ours
+time = { version = "<=0.3.17", features = ["serde"] }
 tokio = { version = "1.20", features = ["fs"] }
 tracing = { version = "0.1", optional = true }
 trust-dns-resolver = { version = "0.22", optional = true }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Pin time <= 0.3.17 until we decide to bump MSRV

Related to https://github.com/time-rs/time/issues/551