### PR TITLE
feat: add dashmap support

### DIFF
--- a/.github/workflows/service_test_dashmap.yml
+++ b/.github/workflows/service_test_dashmap.yml
@@ -1,0 +1,36 @@
+name: Service Test Dashmap
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "!src/docs/**"
+      - "!src/services/**"
+      - "src/services/dashmap/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  dashmap:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Test
+        shell: bash
+        run: cargo test dashmap --features compress,services-dashmap -- --show-output
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: debug
+          OPENDAL_DASHMAP_TEST: on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ layers-metrics = ["dep:metrics"]
 # Enable layers tracing support.
 layers-tracing = ["dep:tracing"]
 
+# Enable services dashmap support
+services-dashmap = ["dep:dashmap"]
 # Enable services hdfs support
 services-hdfs = ["dep:hdrs"]
 # Enable services ftp support
@@ -92,6 +94,7 @@ backon = "0.4.0"
 base64 = "0.21"
 bb8 = { version = "0.8", optional = true }
 bytes = "1.2"
+dashmap = { version = "5.4", optional = true }
 flagset = "0.4"
 futures = { version = "0.3", features = ["alloc"] }
 hdrs = { version = "0.2", optional = true, features = ["async_file"] }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 - [azblob](https://docs.rs/opendal/latest/opendal/services/struct.Azblob.html): [Azure Storage Blob](https://azure.microsoft.com/en-us/services/storage/blobs/) services.
 - [azdfs](https://docs.rs/opendal/latest/opendal/services/struct.Azdfs.html): [Azure Data Lake Storage Gen2](https://azure.microsoft.com/en-us/products/storage/data-lake-storage/) services. (As known as [abfs](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-abfs-driver))
+- [dashmap](https://docs.rs/opendal/latest/opendal/services/struct.Dashmap.html): [dashmap](https://github.com/xacrimon/dashmap) backend support.
 - [fs](https://docs.rs/opendal/latest/opendal/services/struct.Fs.html): POSIX alike file system.
 - [ftp](https://docs.rs/opendal/latest/opendal/services/struct.Ftp.html): FTP and FTPS support.
 - [gcs](https://docs.rs/opendal/latest/opendal/services/struct.Gcs.html): [Google Cloud Storage](https://cloud.google.com/storage) Service.

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -32,6 +32,9 @@ pub enum Scheme {
     Azblob,
     /// [azdfs][crate::services::Azdfs]: Azure Data Lake Storage Gen2.
     Azdfs,
+    /// [dashmap][crate::services::Dashmap]: dashmap backend support.
+    #[cfg(feature = "services-dashmap")]
+    Dashmap,
     /// [fs][crate::services::Fs]: POSIX alike file system.
     Fs,
     /// [gcs][crate::services::Gcs]: Google Cloud Storage backend.
@@ -114,6 +117,8 @@ impl FromStr for Scheme {
         match s.as_str() {
             "azblob" => Ok(Scheme::Azblob),
             "azdfs" => Ok(Scheme::Azdfs),
+            #[cfg(feature = "services-dashmap")]
+            "dashmap" => Ok(Scheme::Dashmap),
             "fs" => Ok(Scheme::Fs),
             "gcs" => Ok(Scheme::Gcs),
             "ghac" => Ok(Scheme::Ghac),
@@ -151,6 +156,8 @@ impl From<Scheme> for &'static str {
         match v {
             Scheme::Azblob => "azblob",
             Scheme::Azdfs => "azdfs",
+            #[cfg(feature = "services-dashmap")]
+            Scheme::Dashmap => "dashmap",
             Scheme::Fs => "fs",
             Scheme::Gcs => "gcs",
             Scheme::Ghac => "ghac",

--- a/src/services/dashmap/backend.rs
+++ b/src/services/dashmap/backend.rs
@@ -1,0 +1,118 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+use crate::raw::adapters::kv;
+use crate::raw::*;
+use crate::*;
+
+/// [dashmap](https://github.com/xacrimon/dashmap) backend support.
+///
+/// # Capabilities
+///
+/// This service can be used to:
+///
+/// - [x] read
+/// - [x] write
+/// - [ ] ~~list~~
+/// - [ ] ~~scan~~
+/// - [ ] ~~presign~~
+/// - [ ] ~~multipart~~
+/// - [x] blocking
+#[derive(Default)]
+pub struct DashmapBuilder {}
+
+impl Builder for DashmapBuilder {
+    const SCHEME: Scheme = Scheme::Dashmap;
+    type Accessor = DashmapBackend;
+
+    fn from_map(_: HashMap<String, String>) -> Self {
+        Self::default()
+    }
+
+    fn build(&mut self) -> Result<Self::Accessor> {
+        Ok(DashmapBackend::new(Adapter {
+            inner: DashMap::default(),
+        }))
+    }
+}
+
+/// Backend is used to serve `Accessor` support in dashmap.
+pub type DashmapBackend = kv::Backend<Adapter>;
+
+#[derive(Debug, Clone)]
+pub struct Adapter {
+    inner: DashMap<String, Vec<u8>>,
+}
+
+#[async_trait]
+impl kv::Adapter for Adapter {
+    fn metadata(&self) -> kv::Metadata {
+        kv::Metadata::new(
+            Scheme::Dashmap,
+            &format!("{:?}", &self.inner as *const _),
+            AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::Scan,
+        )
+    }
+
+    async fn get(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        self.blocking_get(path)
+    }
+
+    fn blocking_get(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        match self.inner.get(path) {
+            None => Ok(None),
+            Some(bs) => Ok(Some(bs.to_vec())),
+        }
+    }
+
+    async fn set(&self, path: &str, value: &[u8]) -> Result<()> {
+        self.blocking_set(path, value)
+    }
+
+    fn blocking_set(&self, path: &str, value: &[u8]) -> Result<()> {
+        self.inner.insert(path.to_string(), value.to_vec());
+
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        self.blocking_delete(path)
+    }
+
+    fn blocking_delete(&self, path: &str) -> Result<()> {
+        self.inner.remove(path);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_accessor_metadata_name() {
+        let b1 = DashmapBuilder::default().build().unwrap();
+        assert_eq!(b1.metadata().name(), b1.metadata().name());
+
+        let b2 = DashmapBuilder::default().build().unwrap();
+        assert_ne!(b1.metadata().name(), b2.metadata().name())
+    }
+}

--- a/src/services/dashmap/backend.rs
+++ b/src/services/dashmap/backend.rs
@@ -67,7 +67,7 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Dashmap,
             &format!("{:?}", &self.inner as *const _),
-            AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::Scan,
+            AccessorCapability::Read | AccessorCapability::Write,
         )
     }
 

--- a/src/services/dashmap/mod.rs
+++ b/src/services/dashmap/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod backend;
+pub use backend::DashmapBuilder as Dashmap;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -22,6 +22,11 @@ pub use azblob::Azblob;
 mod azdfs;
 pub use azdfs::Azdfs;
 
+#[cfg(feature = "services-dashmap")]
+mod dashmap;
+#[cfg(feature = "services-dashmap")]
+pub use self::dashmap::Dashmap;
+
 mod fs;
 pub use fs::Fs;
 

--- a/tests/behavior/main.rs
+++ b/tests/behavior/main.rs
@@ -69,6 +69,7 @@ macro_rules! behavior_tests {
 
 behavior_tests!(Azblob);
 behavior_tests!(Azdfs);
+cfg_if::cfg_if! { if #[cfg(feature = "services-dashmap")] { behavior_tests!(Dashmap); }}
 behavior_tests!(Fs);
 cfg_if::cfg_if! { if #[cfg(feature = "services-ftp")] { behavior_tests!(Ftp); }}
 cfg_if::cfg_if! { if #[cfg(feature = "services-memcached")] { behavior_tests!(Memcached); }}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Refer to the moka and memory implementations.

Tests failure is encountered when the environment variable `OPENDAL_DASHMAP_TEST=on`

```
---- services_dashmap_list::test_list_dir stdout ----
Error: Unsupported (persistent) at scan, context: { called: kv::Adapter::scan, service: dashmap, path: / } => kv adapter doesn't support this operation

failures:
    services_dashmap_list::test_check
    services_dashmap_list::test_list_dir
    services_dashmap_list::test_list_dir_metadata_cache
    services_dashmap_list::test_list_empty_dir
    services_dashmap_list::test_list_nested_dir
    services_dashmap_list::test_list_non_exist_dir
    services_dashmap_list::test_list_rich_dir
    services_dashmap_list::test_list_sub_dir
    services_dashmap_list::test_remove_all
    services_dashmap_list::test_scan
```
