### PR TITLE
refactor: Implement query based object metadata cache

### DIFF
--- a/binaries/oay/src/services/http/mod.rs
+++ b/binaries/oay/src/services/http/mod.rs
@@ -74,11 +74,11 @@ impl Service {
     }
 
     async fn get(&self, req: HttpRequest) -> Result<HttpResponse> {
-        let mut o = self
+        let o = self
             .op
             .object(&percent_decode(req.path().as_bytes()).decode_utf8_lossy());
 
-        let meta = o.metadata().await?;
+        let meta = o.stat().await?;
 
         let (size, r) = if let Some(range) = req.headers().get(header::RANGE) {
             let br = BytesRange::from_str(range.to_str().map_err(|e| {
@@ -164,10 +164,10 @@ impl Service {
     /// - The body's size.
     /// - The body returned by HEAD should not be read.
     async fn head(&self, req: HttpRequest) -> Result<HttpResponse> {
-        let mut o = self
+        let o = self
             .op
             .object(&percent_decode(req.path().as_bytes()).decode_utf8_lossy());
-        let meta = o.metadata().await?;
+        let meta = o.stat().await?;
 
         Ok(HttpResponse::Ok().body(SizedStream::new(
             meta.content_length(),

--- a/binaries/oay/src/services/http/mod.rs
+++ b/binaries/oay/src/services/http/mod.rs
@@ -74,7 +74,7 @@ impl Service {
     }
 
     async fn get(&self, req: HttpRequest) -> Result<HttpResponse> {
-        let o = self
+        let mut o = self
             .op
             .object(&percent_decode(req.path().as_bytes()).decode_utf8_lossy());
 
@@ -103,7 +103,7 @@ impl Service {
     }
 
     async fn put(&self, req: HttpRequest, mut body: web::Payload) -> Result<HttpResponse> {
-        let o = self
+        let mut o = self
             .op
             .object(&percent_decode(req.path().as_bytes()).decode_utf8_lossy());
 
@@ -164,7 +164,7 @@ impl Service {
     /// - The body's size.
     /// - The body returned by HEAD should not be read.
     async fn head(&self, req: HttpRequest) -> Result<HttpResponse> {
-        let o = self
+        let mut o = self
             .op
             .object(&percent_decode(req.path().as_bytes()).decode_utf8_lossy());
         let meta = o.metadata().await?;

--- a/binaries/oli/src/commands/cp.rs
+++ b/binaries/oli/src/commands/cp.rs
@@ -25,7 +25,7 @@ pub async fn main(args: Option<ArgMatches>) -> Result<()> {
         .get_one::<String>("source")
         .ok_or_else(|| anyhow!("missing source"))?;
     let (src_op, src_path) = parse_location(src)?;
-    let mut src_o = src_op.object(src_path);
+    let src_o = src_op.object(src_path);
 
     let dst = args
         .get_one::<String>("destination")
@@ -33,7 +33,7 @@ pub async fn main(args: Option<ArgMatches>) -> Result<()> {
     let (dst_op, dst_path) = parse_location(dst)?;
     let mut dst_o = dst_op.object(dst_path);
 
-    let size = src_o.metadata().await?.content_length();
+    let size = src_o.stat().await?.content_length();
     let reader = src_o.reader().await?;
     dst_o.write_from(size, reader).await?;
     Ok(())

--- a/binaries/oli/src/commands/cp.rs
+++ b/binaries/oli/src/commands/cp.rs
@@ -25,13 +25,13 @@ pub async fn main(args: Option<ArgMatches>) -> Result<()> {
         .get_one::<String>("source")
         .ok_or_else(|| anyhow!("missing source"))?;
     let (src_op, src_path) = parse_location(src)?;
-    let src_o = src_op.object(src_path);
+    let mut src_o = src_op.object(src_path);
 
     let dst = args
         .get_one::<String>("destination")
         .ok_or_else(|| anyhow!("missing target"))?;
     let (dst_op, dst_path) = parse_location(dst)?;
-    let dst_o = dst_op.object(dst_path);
+    let mut dst_o = dst_op.object(dst_path);
 
     let size = src_o.metadata().await?.content_length();
     let reader = src_o.reader().await?;

--- a/bindings/object_store/src/lib.rs
+++ b/bindings/object_store/src/lib.rs
@@ -104,9 +104,9 @@ impl ObjectStore for OpendalStore {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let mut o = self.inner.object(location.as_ref());
+        let o = self.inner.object(location.as_ref());
         let meta = o
-            .metadata()
+            .stat()
             .await
             .map_err(|err| format_object_store_error(err, location.as_ref()))?;
 

--- a/bindings/object_store/src/lib.rs
+++ b/bindings/object_store/src/lib.rs
@@ -56,7 +56,7 @@ impl std::fmt::Display for OpendalStore {
 #[async_trait]
 impl ObjectStore for OpendalStore {
     async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        let o = self.inner.object(location.as_ref());
+        let mut o = self.inner.object(location.as_ref());
         Ok(o.write(bytes)
             .await
             .map_err(|err| format_object_store_error(err, location.as_ref()))?)
@@ -104,7 +104,7 @@ impl ObjectStore for OpendalStore {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let o = self.inner.object(location.as_ref());
+        let mut o = self.inner.object(location.as_ref());
         let meta = o
             .metadata()
             .await
@@ -127,7 +127,7 @@ impl ObjectStore for OpendalStore {
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
-        let o = self.inner.object(location.as_ref());
+        let mut o = self.inner.object(location.as_ref());
         o.delete()
             .await
             .map_err(|err| format_object_store_error(err, location.as_ref()))?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@
 //! use opendal::ErrorKind;
 //! # #[tokio::main]
 //! # async fn test(op: Operator) -> Result<()> {
-//! if let Err(e) = op.object("test_file").metadata().await {
+//! if let Err(e) = op.object("test_file").stat().await {
 //!     if e.kind() == ErrorKind::ObjectNotFound {
 //!         println!("object not exist")
 //!     }

--- a/src/layers/complete.rs
+++ b/src/layers/complete.rs
@@ -292,21 +292,16 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.inner.stat(path, args).await.map(|v| {
-            v.map_metadata(|m| {
-                debug_assert!(!m.is_complete(), "service should not set complete by hand");
-                m.with_complete()
-            })
-        })
+        self.inner
+            .stat(path, args)
+            .await
+            .map(|v| v.map_metadata(|m| m.with_complete()))
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.inner.blocking_stat(path, args).map(|v| {
-            v.map_metadata(|m| {
-                debug_assert!(!m.is_complete(), "service should not set complete by hand");
-                m.with_complete()
-            })
-        })
+        self.inner
+            .blocking_stat(path, args)
+            .map(|v| v.map_metadata(|m| m.with_complete()))
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {

--- a/src/layers/complete.rs
+++ b/src/layers/complete.rs
@@ -291,6 +291,24 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
         self.complete_blocking_reader(path, args)
     }
 
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.inner.stat(path, args).await.map(|v| {
+            v.map_metadata(|m| {
+                debug_assert!(!m.is_complete(), "service should not set complete by hand");
+                m.with_complete()
+            })
+        })
+    }
+
+    fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.inner.blocking_stat(path, args).map(|v| {
+            v.map_metadata(|m| {
+                debug_assert!(!m.is_complete(), "service should not set complete by hand");
+                m.with_complete()
+            })
+        })
+    }
+
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         self.complete_list(path, args).await
     }

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -289,14 +289,17 @@ mod tests {
         let mut map = HashMap::new();
         let mut set = HashSet::new();
         let mut ds = op.object("").list().await?;
-        while let Some(entry) = ds.try_next().await? {
+        while let Some(mut entry) = ds.try_next().await? {
             debug!("got entry: {}", entry.path());
             assert!(
                 set.insert(entry.path().to_string()),
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.stat().await?.mode());
+            map.insert(
+                entry.path().to_string(),
+                entry.metadata(ObjectMetadataKey::Mode).await?.mode(),
+            );
         }
 
         assert_eq!(map["file"], ObjectMode::FILE);
@@ -324,14 +327,17 @@ mod tests {
         let mut ds = op.object("/").scan().await?;
         let mut set = HashSet::new();
         let mut map = HashMap::new();
-        while let Some(entry) = ds.try_next().await? {
+        while let Some(mut entry) = ds.try_next().await? {
             debug!("got entry: {}", entry.path());
             assert!(
                 set.insert(entry.path().to_string()),
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.stat().await?.mode());
+            map.insert(
+                entry.path().to_string(),
+                entry.metadata(ObjectMetadataKey::Mode).await?.mode(),
+            );
         }
 
         debug!("current files: {:?}", map);
@@ -366,13 +372,16 @@ mod tests {
         let mut map = HashMap::new();
         let mut set = HashSet::new();
         let mut ds = op.object("/").list().await?;
-        while let Some(entry) = ds.try_next().await? {
+        while let Some(mut entry) = ds.try_next().await? {
             assert!(
                 set.insert(entry.path().to_string()),
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.stat().await?.mode());
+            map.insert(
+                entry.path().to_string(),
+                entry.metadata(ObjectMetadataKey::Mode).await?.mode(),
+            );
         }
 
         assert_eq!(map.len(), 1);
@@ -382,13 +391,16 @@ mod tests {
         let mut map = HashMap::new();
         let mut set = HashSet::new();
         let mut ds = op.object("dataset/stateful/").list().await?;
-        while let Some(entry) = ds.try_next().await? {
+        while let Some(mut entry) = ds.try_next().await? {
             assert!(
                 set.insert(entry.path().to_string()),
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.stat().await?.mode());
+            map.insert(
+                entry.path().to_string(),
+                entry.metadata(ObjectMetadataKey::Mode).await?.mode(),
+            );
         }
 
         assert_eq!(
@@ -430,13 +442,16 @@ mod tests {
 
         let mut map = HashMap::new();
         let mut set = HashSet::new();
-        while let Some(entry) = ds.try_next().await? {
+        while let Some(mut entry) = ds.try_next().await? {
             assert!(
                 set.insert(entry.path().to_string()),
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.stat().await?.mode());
+            map.insert(
+                entry.path().to_string(),
+                entry.metadata(ObjectMetadataKey::Mode).await?.mode(),
+            );
         }
 
         debug!("current files: {:?}", map);

--- a/src/layers/immutable_index.rs
+++ b/src/layers/immutable_index.rs
@@ -296,7 +296,7 @@ mod tests {
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.mode().await?);
+            map.insert(entry.path().to_string(), entry.stat().await?.mode());
         }
 
         assert_eq!(map["file"], ObjectMode::FILE);
@@ -331,7 +331,7 @@ mod tests {
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.mode().await?);
+            map.insert(entry.path().to_string(), entry.stat().await?.mode());
         }
 
         debug!("current files: {:?}", map);
@@ -372,7 +372,7 @@ mod tests {
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.mode().await?);
+            map.insert(entry.path().to_string(), entry.stat().await?.mode());
         }
 
         assert_eq!(map.len(), 1);
@@ -388,7 +388,7 @@ mod tests {
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.mode().await?);
+            map.insert(entry.path().to_string(), entry.stat().await?.mode());
         }
 
         assert_eq!(
@@ -436,7 +436,7 @@ mod tests {
                 "duplicated value: {}",
                 entry.path()
             );
-            map.insert(entry.path().to_string(), entry.mode().await?);
+            map.insert(entry.path().to_string(), entry.stat().await?.mode());
         }
 
         debug!("current files: {:?}", map);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ mod object;
 pub use object::Object;
 pub use object::ObjectLister;
 pub use object::ObjectMetadata;
+pub use object::ObjectMetadataKey;
 pub use object::ObjectMode;
 pub use object::ObjectMultipart;
 pub use object::ObjectPart;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!         .finish();
 //!
 //!     // Create object handler.
-//!     let o = op.object("test_file");
+//!     let mut o = op.object("test_file");
 //!
 //!     // Write data
 //!     o.write("Hello, World!").await?;
@@ -49,7 +49,7 @@
 //!     let bs = o.read().await?;
 //!
 //!     // Fetch metadata
-//!     let meta = o.metadata().await?;
+//!     let meta = o.stat().await?;
 //!     let mode = meta.mode();
 //!     let length = meta.content_length();
 //!
@@ -117,9 +117,8 @@ mod tests {
         assert_eq!(88, size_of::<AccessorMetadata>());
         assert_eq!(16, size_of::<Operator>());
         assert_eq!(112, size_of::<BatchOperator>());
-        assert_eq!(208, size_of::<output::Entry>());
-        assert_eq!(48, size_of::<Object>());
-        assert_eq!(184, size_of::<ObjectMetadata>());
+        assert_eq!(32, size_of::<Object>());
+        assert_eq!(192, size_of::<ObjectMetadata>());
         assert_eq!(1, size_of::<ObjectMode>());
         assert_eq!(64, size_of::<ObjectMultipart>());
         assert_eq!(32, size_of::<ObjectPart>());

--- a/src/object/blocking_reader.rs
+++ b/src/object/blocking_reader.rs
@@ -14,17 +14,14 @@
 
 use std::io;
 use std::io::SeekFrom;
-use std::sync::Arc;
 
 use bytes::Bytes;
-use parking_lot::Mutex;
 
 use crate::error::Error;
 use crate::error::Result;
 use crate::ops::OpRead;
 use crate::raw::*;
 use crate::ErrorKind;
-use crate::ObjectMetadata;
 
 /// BlockingObjectReader is the public API for users.
 pub struct BlockingObjectReader {
@@ -39,12 +36,7 @@ impl BlockingObjectReader {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) fn create(
-        acc: FusedAccessor,
-        path: &str,
-        _meta: Arc<Mutex<ObjectMetadata>>,
-        op: OpRead,
-    ) -> Result<Self> {
+    pub(crate) fn create(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
         let acc_meta = acc.metadata();
 
         let r = if acc_meta.hints().contains(AccessorHint::ReadSeekable) {

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -58,7 +58,7 @@ impl ObjectMetadata {
         Self {
             // If mode is dir, we will set complete to true.
             complete: mode == ObjectMode::DIR,
-            bit: FlagSet::default(),
+            bit: ObjectMetadataKey::Mode.into(),
 
             mode,
 
@@ -96,12 +96,14 @@ impl ObjectMetadata {
     /// Set mode for object.
     pub fn set_mode(&mut self, mode: ObjectMode) -> &mut Self {
         self.mode = mode;
+        self.bit |= ObjectMetadataKey::Mode;
         self
     }
 
     /// Set mode for object.
     pub fn with_mode(mut self, mode: ObjectMode) -> Self {
         self.mode = mode;
+        self.bit |= ObjectMetadataKey::Mode;
         self
     }
 

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use flagset::{flags, FlagSet};
 use time::OffsetDateTime;
 
 use crate::raw::*;
@@ -28,37 +29,34 @@ use crate::*;
 pub struct ObjectMetadata {
     /// Mark if this metadata is complete or not.
     complete: bool,
+    /// bit stores current key store.
+    bit: FlagSet<ObjectMetadataKey>,
 
     /// Mode of this object.
     mode: ObjectMode,
 
+    /// Content-Disposition of this object
+    content_disposition: Option<String>,
     /// Content Length of this object
-    ///
-    /// # NOTE
-    ///
-    /// - For `stat` operation, content_length is required to set.
-    /// - For `list` operation, content_length could be None.
-    /// - For `read` operation, content_length could be the length of request.
     content_length: Option<u64>,
     /// Content MD5 of this object.
     content_md5: Option<String>,
-    /// Content Type of this object.
-    content_type: Option<String>,
     /// Content Range of this object.
     content_range: Option<BytesContentRange>,
-    /// Last Modified of this object.
-    last_modified: Option<OffsetDateTime>,
+    /// Content Type of this object.
+    content_type: Option<String>,
     /// ETag of this object.
     etag: Option<String>,
-    /// Content-Disposition of this object
-    content_disposition: Option<String>,
+    /// Last Modified of this object.
+    last_modified: Option<OffsetDateTime>,
 }
 
 impl ObjectMetadata {
     /// Create a new object metadata
-    pub const fn new(mode: ObjectMode) -> Self {
+    pub fn new(mode: ObjectMode) -> Self {
         Self {
             complete: false,
+            bit: FlagSet::default(),
 
             mode,
 
@@ -73,20 +71,19 @@ impl ObjectMetadata {
     }
 
     /// If this object metadata if complete
-    pub fn is_complete(&self) -> bool {
+    pub(crate) fn is_complete(&self) -> bool {
         self.complete
     }
 
     /// Make this object metadata if complete.
-    pub fn set_complete(&mut self) -> &mut Self {
+    pub(crate) fn with_complete(mut self) -> Self {
         self.complete = true;
         self
     }
 
-    /// Make this object metadata if complete.
-    pub fn with_complete(mut self) -> Self {
-        self.complete = true;
-        self
+    /// Get the bit from object metadata.
+    pub(crate) fn bit(&self) -> FlagSet<ObjectMetadataKey> {
+        self.bit
     }
 
     /// Object mode represent this object's mode.
@@ -122,12 +119,14 @@ impl ObjectMetadata {
     /// Set content length of this object.
     pub fn set_content_length(&mut self, content_length: u64) -> &mut Self {
         self.content_length = Some(content_length);
+        self.bit |= ObjectMetadataKey::ContentLength;
         self
     }
 
     /// Set content length of this object.
     pub fn with_content_length(mut self, content_length: u64) -> Self {
         self.content_length = Some(content_length);
+        self.bit |= ObjectMetadataKey::ContentLength;
         self
     }
 
@@ -147,6 +146,7 @@ impl ObjectMetadata {
     /// And removed by [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231).
     pub fn set_content_md5(&mut self, content_md5: &str) -> &mut Self {
         self.content_md5 = Some(content_md5.to_string());
+        self.bit |= ObjectMetadataKey::ContentMd5;
         self
     }
 
@@ -154,8 +154,9 @@ impl ObjectMetadata {
     ///
     /// Content MD5 is defined by [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
     /// And removed by [RFC 7231](https://www.rfc-editor.org/rfc/rfc7231).
-    pub fn with_content_md5(mut self, content_md5: &str) -> Self {
-        self.content_md5 = Some(content_md5.to_string());
+    pub fn with_content_md5(mut self, content_md5: String) -> Self {
+        self.content_md5 = Some(content_md5);
+        self.bit |= ObjectMetadataKey::ContentMd5;
         self
     }
 
@@ -171,14 +172,16 @@ impl ObjectMetadata {
     /// Content Type is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-type).
     pub fn set_content_type(&mut self, v: &str) -> &mut Self {
         self.content_type = Some(v.to_string());
+        self.bit |= ObjectMetadataKey::ContentType;
         self
     }
 
     /// Set Content Type of this object.
     ///
     /// Content Type is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-type).
-    pub fn with_content_type(mut self, v: &str) -> Self {
-        self.content_type = Some(v.to_string());
+    pub fn with_content_type(mut self, v: String) -> Self {
+        self.content_type = Some(v);
+        self.bit |= ObjectMetadataKey::ContentType;
         self
     }
 
@@ -194,6 +197,7 @@ impl ObjectMetadata {
     /// Content Range is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-range).
     pub fn set_content_range(&mut self, v: BytesContentRange) -> &mut Self {
         self.content_range = Some(v);
+        self.bit |= ObjectMetadataKey::ContentRange;
         self
     }
 
@@ -202,6 +206,7 @@ impl ObjectMetadata {
     /// Content Range is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-range).
     pub fn with_content_range(mut self, v: BytesContentRange) -> Self {
         self.content_range = Some(v);
+        self.bit |= ObjectMetadataKey::ContentRange;
         self
     }
 
@@ -221,6 +226,7 @@ impl ObjectMetadata {
     /// Refer to [MDN Last-Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) for more information.
     pub fn set_last_modified(&mut self, last_modified: OffsetDateTime) -> &mut Self {
         self.last_modified = Some(last_modified);
+        self.bit |= ObjectMetadataKey::LastModified;
         self
     }
 
@@ -230,6 +236,7 @@ impl ObjectMetadata {
     /// Refer to [MDN Last-Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) for more information.
     pub fn with_last_modified(mut self, last_modified: OffsetDateTime) -> Self {
         self.last_modified = Some(last_modified);
+        self.bit |= ObjectMetadataKey::LastModified;
         self
     }
 
@@ -261,6 +268,7 @@ impl ObjectMetadata {
     /// `"` is part of etag, don't trim it before setting.
     pub fn set_etag(&mut self, etag: &str) -> &mut Self {
         self.etag = Some(etag.to_string());
+        self.bit |= ObjectMetadataKey::Etag;
         self
     }
 
@@ -275,8 +283,9 @@ impl ObjectMetadata {
     /// - `W/"0815"`
     ///
     /// `"` is part of etag, don't trim it before setting.
-    pub fn with_etag(mut self, etag: &str) -> Self {
-        self.etag = Some(etag.to_string());
+    pub fn with_etag(mut self, etag: String) -> Self {
+        self.etag = Some(etag);
+        self.bit |= ObjectMetadataKey::Etag;
         self
     }
 
@@ -306,8 +315,9 @@ impl ObjectMetadata {
     /// - "inline"
     /// - "attachment"
     /// - "attachment; filename=\"filename.jpg\""
-    pub fn with_content_disposition(mut self, content_disposition: &str) -> Self {
-        self.content_disposition = Some(content_disposition.to_string());
+    pub fn with_content_disposition(mut self, content_disposition: String) -> Self {
+        self.content_disposition = Some(content_disposition);
+        self.bit |= ObjectMetadataKey::ContentDisposition;
         self
     }
 
@@ -324,6 +334,41 @@ impl ObjectMetadata {
     /// - "attachment; filename=\"filename.jpg\""
     pub fn set_content_disposition(&mut self, content_disposition: &str) -> &mut Self {
         self.content_disposition = Some(content_disposition.to_string());
+        self.bit |= ObjectMetadataKey::ContentDisposition;
         self
+    }
+}
+
+flags! {
+    /// ObjectMetadataKey describes the metadata keys that can be stored
+    /// or quried.
+    ///
+    /// ## For store
+    ///
+    /// Internally, we will store a flag set of ObjectMetadataKey to check
+    /// whether we have set some key already.
+    ///
+    /// ## For query
+    ///
+    /// At user side, we will allow user to query the object metadata. If
+    /// the meta has been stored, we will return directly. If no, we will
+    /// call `stat` internally to fecth the metadata.
+    pub enum ObjectMetadataKey: u64 {
+        /// Key for mode.
+        Mode,
+        /// Key for content disposition.
+        ContentDisposition,
+        /// Key for content length.
+        ContentLength,
+        /// Key for content md5.
+        ContentMd5,
+        /// Key for content range.
+        ContentRange,
+        /// Key for content type.
+        ContentType,
+        /// Key for etag.
+        Etag,
+        /// Key for last last modified.
+        LastModified,
     }
 }

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -55,7 +55,8 @@ impl ObjectMetadata {
     /// Create a new object metadata
     pub fn new(mode: ObjectMode) -> Self {
         Self {
-            complete: false,
+            // If mode is dir, we will set complete to true.
+            complete: mode == ObjectMode::DIR,
             bit: FlagSet::default(),
 
             mode,

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use flagset::{flags, FlagSet};
+use flagset::flags;
+use flagset::FlagSet;
 use time::OffsetDateTime;
 
 use crate::raw::*;

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -24,7 +24,7 @@ use crate::*;
 /// mode and content_length are required metadata that all services
 /// should provide during `stat` operation. But in `list` operation,
 /// a.k.a., `Entry`'s content length could be `None`.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ObjectMetadata {
     /// Mark if this metadata is complete or not.
     complete: bool,

--- a/src/object/metadata.rs
+++ b/src/object/metadata.rs
@@ -56,7 +56,7 @@ pub struct ObjectMetadata {
 
 impl ObjectMetadata {
     /// Create a new object metadata
-    pub fn new(mode: ObjectMode) -> Self {
+    pub const fn new(mode: ObjectMode) -> Self {
         Self {
             complete: false,
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -17,6 +17,7 @@ pub use mode::ObjectMode;
 
 mod metadata;
 pub use metadata::ObjectMetadata;
+pub use metadata::ObjectMetadataKey;
 
 mod multipart;
 pub use multipart::ObjectMultipart;

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -41,7 +41,7 @@ use crate::*;
 #[derive(Clone, Debug)]
 pub struct Object {
     acc: FusedAccessor,
-    path: String,
+    path: Arc<String>,
 
     meta: Arc<Mutex<ObjectMetadata>>,
 }
@@ -59,7 +59,7 @@ impl Object {
     pub(crate) fn with(op: Operator, path: &str, meta: ObjectMetadata) -> Self {
         Self {
             acc: op.inner(),
-            path: normalize_path(path),
+            path: Arc::new(normalize_path(path)),
             meta: Arc::new(Mutex::new(meta)),
         }
     }

--- a/src/object/object.rs
+++ b/src/object/object.rs
@@ -504,7 +504,7 @@ impl Object {
 
         let op = OpRead::new().with_range(range.into());
 
-        BlockingObjectReader::create(self.accessor(), self.path(), self.meta.clone(), op)
+        BlockingObjectReader::create(self.accessor(), self.path(), op)
     }
 
     /// Read the whole object into a bytes with auto detected compress algorithm.

--- a/src/object/reader.rs
+++ b/src/object/reader.rs
@@ -240,7 +240,7 @@ mod tests {
         let op = Operator::create(services::Memory::default())
             .unwrap()
             .finish();
-        let obj = op.object("test_file");
+        let mut obj = op.object("test_file");
 
         let content = gen_random_bytes();
         obj.write(&*content)
@@ -262,7 +262,7 @@ mod tests {
         let op = Operator::create(services::Memory::default())
             .unwrap()
             .finish();
-        let obj = op.object("test_file");
+        let mut obj = op.object("test_file");
 
         let content = gen_random_bytes();
         obj.write(&*content)

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -504,7 +504,7 @@ impl BatchOperator {
     /// # }
     /// ```
     pub async fn remove_all(&self, path: &str) -> Result<()> {
-        let parent = self.src.object(path);
+        let mut parent = self.src.object(path);
         let meta = parent.metadata().await?;
 
         if meta.mode() != ObjectMode::DIR {
@@ -537,7 +537,7 @@ impl BatchOperator {
                 }
             }
         } else {
-            obs.try_for_each(|v| async move { v.delete().await })
+            obs.try_for_each(|mut v| async move { v.delete().await })
                 .await?;
         }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -505,13 +505,13 @@ impl BatchOperator {
     /// ```
     pub async fn remove_all(&self, path: &str) -> Result<()> {
         let mut parent = self.src.object(path);
-        let meta = parent.metadata().await?;
+        let meta = parent.stat().await?;
 
         if meta.mode() != ObjectMode::DIR {
             return parent.delete().await;
         }
 
-        let obs = self.src.object(path).scan().await?;
+        let obs = parent.scan().await?;
 
         if self.meta.can_batch() {
             let mut obs = obs.try_chunks(self.limit);

--- a/src/raw/io/output/entry.rs
+++ b/src/raw/io/output/entry.rs
@@ -71,6 +71,6 @@ impl Entry {
 
     /// Consume to convert into an object.
     pub fn into_object(self, op: Operator) -> Object {
-        Object::with(op, &self.path, self.meta)
+        Object::with(op, &self.path, Some(self.meta))
     }
 }

--- a/src/raw/rps.rs
+++ b/src/raw/rps.rs
@@ -261,7 +261,7 @@ impl RpStat {
         RpStat { meta }
     }
 
-/// Operate on inner metadata.
+    /// Operate on inner metadata.
     pub fn map_metadata(mut self, f: impl FnOnce(ObjectMetadata) -> ObjectMetadata) -> Self {
         self.meta = f(self.meta);
         self

--- a/src/raw/rps.rs
+++ b/src/raw/rps.rs
@@ -261,6 +261,12 @@ impl RpStat {
         RpStat { meta }
     }
 
+/// Operate on inner metadata.
+    pub fn map_metadata(mut self, f: impl FnOnce(ObjectMetadata) -> ObjectMetadata) -> Self {
+        self.meta = f(self.meta);
+        self
+    }
+
     /// Consume RpStat to get the inner metadata.
     pub fn into_metadata(self) -> ObjectMetadata {
         self.meta

--- a/src/services/azblob/dir_stream.rs
+++ b/src/services/azblob/dir_stream.rs
@@ -109,10 +109,10 @@ impl output::Page for DirStream {
 
             let meta = ObjectMetadata::new(ObjectMode::FILE)
                 // Keep fit with ETag header.
-                .with_etag(&format!("\"{}\"", object.properties.etag.as_str()))
+                .with_etag(format!("\"{}\"", object.properties.etag.as_str()))
                 .with_content_length(object.properties.content_length)
-                .with_content_md5(object.properties.content_md5.as_str())
-                .with_content_type(&object.properties.content_type)
+                .with_content_md5(object.properties.content_md5)
+                .with_content_type(object.properties.content_type)
                 .with_last_modified(
                     OffsetDateTime::parse(object.properties.last_modified.as_str(), &Rfc2822)
                         .map_err(|e| {

--- a/src/services/azblob/dir_stream.rs
+++ b/src/services/azblob/dir_stream.rs
@@ -93,7 +93,7 @@ impl output::Page for DirStream {
         for prefix in prefixes {
             let de = output::Entry::new(
                 &build_rel_path(&self.root, &prefix.name),
-                ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                ObjectMetadata::new(ObjectMode::DIR),
             );
 
             entries.push(de)
@@ -122,8 +122,7 @@ impl output::Page for DirStream {
                             )
                             .set_source(e)
                         })?,
-                )
-                .with_complete();
+                );
 
             let de = output::Entry::new(&build_rel_path(&self.root, &object.name), meta);
 

--- a/src/services/azdfs/dir_stream.rs
+++ b/src/services/azdfs/dir_stream.rs
@@ -104,7 +104,7 @@ impl output::Page for DirStream {
 
             let meta = ObjectMetadata::new(mode)
                 // Keep fit with ETag header.
-                .with_etag(&format!("\"{}\"", &object.etag))
+                .with_etag(format!("\"{}\"", &object.etag))
                 .with_content_length(object.content_length.parse().map_err(|err| {
                     Error::new(ErrorKind::Unexpected, "content length is not valid integer")
                         .set_source(err)

--- a/src/services/azdfs/dir_stream.rs
+++ b/src/services/azdfs/dir_stream.rs
@@ -117,8 +117,7 @@ impl output::Page for DirStream {
                         )
                         .set_source(e)
                     })?,
-                )
-                .with_complete();
+                );
 
             let mut path = build_rel_path(&self.root, &object.name);
             if mode == ObjectMode::DIR {

--- a/src/services/fs/dir_stream.rs
+++ b/src/services/fs/dir_stream.rs
@@ -72,7 +72,7 @@ impl output::Page for DirPager {
                 // Make sure we are returning the correct path.
                 output::Entry::new(
                     &format!("{rel_path}/"),
-                    ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                    ObjectMetadata::new(ObjectMode::DIR),
                 )
             } else {
                 output::Entry::new(&rel_path, ObjectMetadata::new(ObjectMode::Unknown))
@@ -133,7 +133,7 @@ impl output::BlockingPage for BlockingDirPager {
                 // Make sure we are returning the correct path.
                 output::Entry::new(
                     &format!("{rel_path}/"),
-                    ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                    ObjectMetadata::new(ObjectMode::DIR),
                 )
             } else {
                 output::Entry::new(&rel_path, ObjectMetadata::new(ObjectMode::Unknown))

--- a/src/services/ftp/dir_stream.rs
+++ b/src/services/ftp/dir_stream.rs
@@ -86,19 +86,12 @@ impl output::Page for DirStream {
                     &path,
                     ObjectMetadata::new(ObjectMode::FILE)
                         .with_content_length(de.size() as u64)
-                        .with_last_modified(OffsetDateTime::from(de.modified()))
-                        .with_complete(),
+                        .with_last_modified(OffsetDateTime::from(de.modified())),
                 )
             } else if de.is_directory() {
-                output::Entry::new(
-                    &format!("{}/", &path),
-                    ObjectMetadata::new(ObjectMode::DIR).with_complete(),
-                )
+                output::Entry::new(&format!("{}/", &path), ObjectMetadata::new(ObjectMode::DIR))
             } else {
-                output::Entry::new(
-                    &path,
-                    ObjectMetadata::new(ObjectMode::Unknown).with_complete(),
-                )
+                output::Entry::new(&path, ObjectMetadata::new(ObjectMode::Unknown))
             };
 
             oes.push(d)

--- a/src/services/gcs/dir_stream.rs
+++ b/src/services/gcs/dir_stream.rs
@@ -91,7 +91,7 @@ impl output::Page for DirStream {
         for prefix in output.prefixes {
             let de = output::Entry::new(
                 &build_rel_path(&self.root, &prefix),
-                ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                ObjectMetadata::new(ObjectMode::DIR),
             );
 
             entries.push(de);

--- a/src/services/gcs/dir_stream.rs
+++ b/src/services/gcs/dir_stream.rs
@@ -120,7 +120,6 @@ impl output::Page for DirStream {
                 Error::new(ErrorKind::Unexpected, "parse last modified as rfc3339").set_source(e)
             })?;
             meta.set_last_modified(dt);
-            meta.set_complete();
 
             let de = output::Entry::new(&build_rel_path(&self.root, &object.name), meta);
 

--- a/src/services/hdfs/dir_stream.rs
+++ b/src/services/hdfs/dir_stream.rs
@@ -57,10 +57,7 @@ impl output::Page for DirStream {
                 output::Entry::new(&path, meta)
             } else if de.is_dir() {
                 // Make sure we are returning the correct path.
-                output::Entry::new(
-                    &format!("{path}/"),
-                    ObjectMetadata::new(ObjectMode::DIR).with_complete(),
-                )
+                output::Entry::new(&format!("{path}/"), ObjectMetadata::new(ObjectMode::DIR))
             } else {
                 output::Entry::new(&path, ObjectMetadata::new(ObjectMode::Unknown))
             };
@@ -91,10 +88,7 @@ impl output::BlockingPage for DirStream {
                 output::Entry::new(&path, meta)
             } else if de.is_dir() {
                 // Make sure we are returning the correct path.
-                output::Entry::new(
-                    &format!("{path}/"),
-                    ObjectMetadata::new(ObjectMode::DIR).with_complete(),
-                )
+                output::Entry::new(&format!("{path}/"), ObjectMetadata::new(ObjectMode::DIR))
             } else {
                 output::Entry::new(&path, ObjectMetadata::new(ObjectMode::Unknown))
             };

--- a/src/services/http/backend.rs
+++ b/src/services/http/backend.rs
@@ -456,7 +456,8 @@ mod tests {
         builder.root("/");
         let op = Operator::create(builder)?.finish();
 
-        let bs = op.object("hello").metadata().await?;
+        let o = op.object("hello");
+        let bs = o.stat().await?;
 
         assert_eq!(bs.mode(), ObjectMode::FILE);
         assert_eq!(bs.content_length(), 128);

--- a/src/services/ipfs/backend.rs
+++ b/src/services/ipfs/backend.rs
@@ -503,7 +503,7 @@ impl output::Page for DirStream {
                 name += "/";
             }
 
-            oes.push(output::Entry::new(&name, meta.with_complete()))
+            oes.push(output::Entry::new(&name, meta))
         }
 
         self.consumed = true;

--- a/src/services/ipmfs/dir_stream.rs
+++ b/src/services/ipmfs/dir_stream.rs
@@ -83,9 +83,7 @@ impl output::Page for DirStream {
 
                     output::Entry::new(
                         &path,
-                        ObjectMetadata::new(object.mode())
-                            .with_content_length(object.size)
-                            .with_complete(),
+                        ObjectMetadata::new(object.mode()).with_content_length(object.size),
                     )
                 })
                 .collect(),

--- a/src/services/obs/dir_stream.rs
+++ b/src/services/obs/dir_stream.rs
@@ -96,7 +96,7 @@ impl output::Page for DirStream {
         for prefix in common_prefixes {
             let de = output::Entry::new(
                 &build_rel_path(&self.root, &prefix.prefix),
-                ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                ObjectMetadata::new(ObjectMode::DIR),
             );
 
             entries.push(de);

--- a/src/services/oss/dir_stream.rs
+++ b/src/services/oss/dir_stream.rs
@@ -98,7 +98,7 @@ impl output::Page for DirStream {
         for prefix in output.common_prefixes {
             let de = output::Entry::new(
                 &build_rel_path(&self.root, &prefix.prefix),
-                ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                ObjectMetadata::new(ObjectMode::DIR),
             );
             entries.push(de);
         }
@@ -107,7 +107,7 @@ impl output::Page for DirStream {
             if object.key.ends_with('/') {
                 continue;
             }
-            let mut meta = ObjectMetadata::new(ObjectMode::FILE).with_complete();
+            let mut meta = ObjectMetadata::new(ObjectMode::FILE);
 
             meta.set_etag(&object.etag);
             meta.set_content_length(object.size);

--- a/src/services/s3/dir_stream.rs
+++ b/src/services/s3/dir_stream.rs
@@ -101,7 +101,7 @@ impl output::Page for DirStream {
         for prefix in output.common_prefixes {
             let de = output::Entry::new(
                 &build_rel_path(&self.root, &prefix.prefix),
-                ObjectMetadata::new(ObjectMode::DIR).with_complete(),
+                ObjectMetadata::new(ObjectMode::DIR),
             );
 
             entries.push(de);
@@ -115,7 +115,7 @@ impl output::Page for DirStream {
                 continue;
             }
 
-            let mut meta = ObjectMetadata::new(ObjectMode::FILE).with_complete();
+            let mut meta = ObjectMetadata::new(ObjectMode::FILE);
 
             meta.set_etag(&object.etag);
             meta.set_content_md5(object.etag.trim_matches('"'));

--- a/src/services/webdav/dir_stream.rs
+++ b/src/services/webdav/dir_stream.rs
@@ -65,10 +65,7 @@ impl output::Page for DirStream {
                 let entry = if de.propstat.prop.resourcetype.value
                     == Some(super::list_response::ResourceType::Collection)
                 {
-                    output::Entry::new(
-                        &normalized_path,
-                        ObjectMetadata::new(ObjectMode::DIR).with_complete(),
-                    )
+                    output::Entry::new(&normalized_path, ObjectMetadata::new(ObjectMode::DIR))
                 } else {
                     output::Entry::new(&normalized_path, ObjectMetadata::new(ObjectMode::FILE))
                 };

--- a/tests/behavior/blocking_list.rs
+++ b/tests/behavior/blocking_list.rs
@@ -88,7 +88,7 @@ pub fn test_list_dir(op: Operator) -> Result<()> {
     let mut found = false;
     for de in obs {
         let de = de?;
-        let meta = de.blocking_metadata()?;
+        let meta = de.blocking_stat()?;
         if de.path() == path {
             assert_eq!(meta.mode(), ObjectMode::FILE);
             assert_eq!(meta.content_length(), size as u64);

--- a/tests/behavior/blocking_read.rs
+++ b/tests/behavior/blocking_read.rs
@@ -75,11 +75,11 @@ macro_rules! behavior_blocking_read_tests {
 
 /// Stat normal file and dir should return metadata
 pub fn test_stat(op: Operator) -> Result<()> {
-    let meta = op.object("normal_file").blocking_metadata()?;
+    let meta = op.object("normal_file").blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 262144);
 
-    let meta = op.object("normal_dir/").blocking_metadata()?;
+    let meta = op.object("normal_dir/").blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())
@@ -89,13 +89,13 @@ pub fn test_stat(op: Operator) -> Result<()> {
 pub fn test_stat_special_chars(op: Operator) -> Result<()> {
     let meta = op
         .object("special_file  !@#$%^&()_+-=;',")
-        .blocking_metadata()?;
+        .blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 262144);
 
     let meta = op
         .object("special_dir  !@#$%^&()_+-=;',/")
-        .blocking_metadata()?;
+        .blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())
@@ -105,7 +105,7 @@ pub fn test_stat_special_chars(op: Operator) -> Result<()> {
 pub fn test_stat_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let meta = op.object(&path).blocking_metadata();
+    let meta = op.object(&path).blocking_stat();
     assert!(meta.is_err());
     assert_eq!(meta.unwrap_err().kind(), ErrorKind::ObjectNotFound);
 

--- a/tests/behavior/blocking_write.rs
+++ b/tests/behavior/blocking_write.rs
@@ -194,10 +194,7 @@ pub fn test_write(op: Operator) -> Result<()> {
 
     op.object(&path).blocking_write(content)?;
 
-    let meta = op
-        .object(&path)
-        .blocking_metadata()
-        .expect("stat must succeed");
+    let meta = op.object(&path).blocking_stat().expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)
@@ -226,10 +223,7 @@ pub fn test_write_with_special_chars(op: Operator) -> Result<()> {
 
     op.object(&path).blocking_write(content)?;
 
-    let meta = op
-        .object(&path)
-        .blocking_metadata()
-        .expect("stat must succeed");
+    let meta = op.object(&path).blocking_stat().expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)
@@ -248,7 +242,7 @@ pub fn test_stat(op: Operator) -> Result<()> {
         .blocking_write(content)
         .expect("write must succeed");
 
-    let meta = op.object(&path).blocking_metadata()?;
+    let meta = op.object(&path).blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 
@@ -266,7 +260,7 @@ pub fn test_stat_dir(op: Operator) -> Result<()> {
         .blocking_create()
         .expect("write must succeed");
 
-    let meta = op.object(&path).blocking_metadata()?;
+    let meta = op.object(&path).blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)
@@ -285,7 +279,7 @@ pub fn test_stat_with_special_chars(op: Operator) -> Result<()> {
         .blocking_write(content)
         .expect("write must succeed");
 
-    let meta = op.object(&path).blocking_metadata()?;
+    let meta = op.object(&path).blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 
@@ -299,7 +293,7 @@ pub fn test_stat_with_special_chars(op: Operator) -> Result<()> {
 pub fn test_stat_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let meta = op.object(&path).blocking_metadata();
+    let meta = op.object(&path).blocking_stat();
     assert!(meta.is_err());
     assert_eq!(meta.unwrap_err().kind(), ErrorKind::ObjectNotFound);
 

--- a/tests/behavior/blocking_write.rs
+++ b/tests/behavior/blocking_write.rs
@@ -97,11 +97,11 @@ macro_rules! behavior_blocking_write_tests {
 pub fn test_create_file(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.blocking_create()?;
 
-    let meta = o.blocking_metadata()?;
+    let meta = o.blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -115,13 +115,13 @@ pub fn test_create_file(op: Operator) -> Result<()> {
 pub fn test_create_file_existing(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.blocking_create()?;
 
     o.blocking_create()?;
 
-    let meta = o.blocking_metadata()?;
+    let meta = o.blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -135,12 +135,12 @@ pub fn test_create_file_existing(op: Operator) -> Result<()> {
 pub fn test_create_file_with_special_chars(op: Operator) -> Result<()> {
     let path = format!("{} !@#$%^&()_+-=;',.txt", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
     debug!("{o:?}");
 
     o.blocking_create()?;
 
-    let meta = o.blocking_metadata()?;
+    let meta = o.blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -154,11 +154,11 @@ pub fn test_create_file_with_special_chars(op: Operator) -> Result<()> {
 pub fn test_create_dir(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.blocking_create()?;
 
-    let meta = o.blocking_metadata()?;
+    let meta = o.blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)
@@ -171,13 +171,13 @@ pub fn test_create_dir(op: Operator) -> Result<()> {
 pub fn test_create_dir_existing(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.blocking_create()?;
 
     o.blocking_create()?;
 
-    let meta = o.blocking_metadata()?;
+    let meta = o.blocking_stat()?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)

--- a/tests/behavior/list.rs
+++ b/tests/behavior/list.rs
@@ -228,7 +228,7 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
     let mut found = false;
     while let Some(de) = obs.try_next().await? {
         if de.path() == path {
-            assert_eq!(de.mode().await?, ObjectMode::DIR);
+            assert_eq!(de.stat().await?.mode(), ObjectMode::DIR);
             assert_eq!(de.name(), path);
 
             found = true

--- a/tests/behavior/list.rs
+++ b/tests/behavior/list.rs
@@ -73,7 +73,6 @@ macro_rules! behavior_list_tests {
                 test_check,
                 test_list_dir,
                 test_list_rich_dir,
-                test_list_dir_metadata_cache,
                 test_list_empty_dir,
                 test_list_non_exist_dir,
                 test_list_sub_dir,
@@ -107,7 +106,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
     let mut obs = op.object("/").list().await?;
     let mut found = false;
     while let Some(de) = obs.try_next().await? {
-        let meta = de.metadata().await?;
+        let meta = de.stat().await?;
         if de.path() == path {
             assert_eq!(meta.mode(), ObjectMode::FILE);
             assert_eq!(meta.content_length(), size as u64);
@@ -135,7 +134,7 @@ pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
     expected
         .iter()
         .map(|v| async {
-            let o = op.object(v);
+            let mut o = op.object(v);
             o.create().await.expect("create must succeed");
         })
         // Collect into a FuturesUnordered.
@@ -156,31 +155,6 @@ pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
     assert_eq!(actual, expected);
 
     op.batch().remove_all("test_list_rich_dir/").await?;
-    Ok(())
-}
-
-/// List dir should return newly created file with correct metadata.
-pub async fn test_list_dir_metadata_cache(op: Operator) -> Result<()> {
-    let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
-    let (content, _) = gen_bytes();
-
-    op.object(&path)
-        .write(content)
-        .await
-        .expect("write must succeed");
-
-    let mut obs = op.object("/").list().await?;
-    while let Some(de) = obs.try_next().await? {
-        let meta_from_raw = de.stat().await?;
-        let meta_from_cache = de.metadata().await?;
-        assert_eq!(meta_from_raw, meta_from_cache)
-    }
-
-    op.object(&path)
-        .delete()
-        .await
-        .expect("delete must succeed");
     Ok(())
 }
 
@@ -276,7 +250,7 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
     let meta = objects
         .get(&file_path)
         .expect("file should be found in list")
-        .metadata()
+        .stat()
         .await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
@@ -285,7 +259,7 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
     let meta = objects
         .get(&dir_path)
         .expect("file should be found in list")
-        .metadata()
+        .stat()
         .await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 

--- a/tests/behavior/list_only.rs
+++ b/tests/behavior/list_only.rs
@@ -71,7 +71,7 @@ pub async fn test_list(op: Operator) -> Result<()> {
 
     let mut ds = op.object("/").list().await?;
     while let Some(de) = ds.try_next().await? {
-        entries.insert(de.path().to_string(), de.metadata().await?.mode());
+        entries.insert(de.path().to_string(), de.stat().await?.mode());
     }
 
     assert_eq!(entries["normal_file"], ObjectMode::FILE);

--- a/tests/behavior/multipart.rs
+++ b/tests/behavior/multipart.rs
@@ -85,7 +85,7 @@ pub async fn test_multipart_complete(op: Operator) -> Result<()> {
     // Complete
     let o = mp.complete(vec![p1, p2]).await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
 
     assert_eq!(10 * 1024 * 1024, meta.content_length(), "complete size");
     assert_eq!(

--- a/tests/behavior/multipart_presign.rs
+++ b/tests/behavior/multipart_presign.rs
@@ -111,7 +111,7 @@ pub async fn test_presign_write_multipart(op: Operator) -> Result<()> {
 
     let o = mp.complete(vec![ObjectPart::new(1, etag)]).await?;
 
-    let meta = o.metadata().await.expect("stat must succeed");
+    let meta = o.stat().await.expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)

--- a/tests/behavior/presign.rs
+++ b/tests/behavior/presign.rs
@@ -101,11 +101,7 @@ pub async fn test_presign_write(op: Operator) -> Result<()> {
         resp.text().await.expect("read response must succeed")
     );
 
-    let meta = op
-        .object(&path)
-        .metadata()
-        .await
-        .expect("stat must succeed");
+    let meta = op.object(&path).stat().await.expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)

--- a/tests/behavior/read_only.rs
+++ b/tests/behavior/read_only.rs
@@ -86,11 +86,11 @@ macro_rules! behavior_read_tests {
 
 /// Stat normal file and dir should return metadata
 pub async fn test_stat(op: Operator) -> Result<()> {
-    let meta = op.object("normal_file").metadata().await?;
+    let meta = op.object("normal_file").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 262144);
 
-    let meta = op.object("normal_dir/").metadata().await?;
+    let meta = op.object("normal_dir/").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())
@@ -98,17 +98,11 @@ pub async fn test_stat(op: Operator) -> Result<()> {
 
 /// Stat special file and dir should return metadata
 pub async fn test_stat_special_chars(op: Operator) -> Result<()> {
-    let meta = op
-        .object("special_file  !@#$%^&()_+-=;',")
-        .metadata()
-        .await?;
+    let meta = op.object("special_file  !@#$%^&()_+-=;',").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 262144);
 
-    let meta = op
-        .object("special_dir  !@#$%^&()_+-=;',/")
-        .metadata()
-        .await?;
+    let meta = op.object("special_dir  !@#$%^&()_+-=;',/").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())
@@ -116,7 +110,7 @@ pub async fn test_stat_special_chars(op: Operator) -> Result<()> {
 
 /// Stat not cleaned path should also succeed.
 pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
-    let meta = op.object("//normal_file").metadata().await?;
+    let meta = op.object("//normal_file").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 262144);
 
@@ -127,7 +121,7 @@ pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
 pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let meta = op.object(&path).metadata().await;
+    let meta = op.object(&path).stat().await;
     assert!(meta.is_err());
     assert_eq!(meta.unwrap_err().kind(), ErrorKind::ObjectNotFound);
 
@@ -136,10 +130,10 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Root should be able to stat and returns DIR.
 pub async fn test_stat_root(op: Operator) -> Result<()> {
-    let meta = op.object("").metadata().await?;
+    let meta = op.object("").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
-    let meta = op.object("/").metadata().await?;
+    let meta = op.object("/").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())

--- a/tests/behavior/write.rs
+++ b/tests/behavior/write.rs
@@ -210,11 +210,7 @@ pub async fn test_write(op: Operator) -> Result<()> {
 
     op.object(&path).write(content).await?;
 
-    let meta = op
-        .object(&path)
-        .metadata()
-        .await
-        .expect("stat must succeed");
+    let meta = op.object(&path).stat().await.expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)
@@ -243,11 +239,7 @@ pub async fn test_write_with_special_chars(op: Operator) -> Result<()> {
 
     op.object(&path).write(content).await?;
 
-    let meta = op
-        .object(&path)
-        .metadata()
-        .await
-        .expect("stat must succeed");
+    let meta = op.object(&path).stat().await.expect("stat must succeed");
     assert_eq!(meta.content_length(), size as u64);
 
     op.object(&path)
@@ -267,7 +259,7 @@ pub async fn test_stat(op: Operator) -> Result<()> {
         .await
         .expect("write must succeed");
 
-    let meta = op.object(&path).metadata().await?;
+    let meta = op.object(&path).stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 
@@ -284,7 +276,7 @@ pub async fn test_stat_dir(op: Operator) -> Result<()> {
 
     op.object(&path).create().await.expect("write must succeed");
 
-    let meta = op.object(&path).metadata().await?;
+    let meta = op.object(&path).stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)
@@ -304,7 +296,7 @@ pub async fn test_stat_with_special_chars(op: Operator) -> Result<()> {
         .await
         .expect("write must succeed");
 
-    let meta = op.object(&path).metadata().await?;
+    let meta = op.object(&path).stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 
@@ -326,7 +318,7 @@ pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
         .await
         .expect("write must succeed");
 
-    let meta = op.object(&format!("//{}", &path)).metadata().await?;
+    let meta = op.object(&format!("//{}", &path)).stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 
@@ -341,7 +333,7 @@ pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
 pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let meta = op.object(&path).metadata().await;
+    let meta = op.object(&path).stat().await;
     assert!(meta.is_err());
     assert_eq!(meta.unwrap_err().kind(), ErrorKind::ObjectNotFound);
 
@@ -350,10 +342,10 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Root should be able to stat and returns DIR.
 pub async fn test_stat_root(op: Operator) -> Result<()> {
-    let meta = op.object("").metadata().await?;
+    let meta = op.object("").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
-    let meta = op.object("/").metadata().await?;
+    let meta = op.object("/").stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     Ok(())

--- a/tests/behavior/write.rs
+++ b/tests/behavior/write.rs
@@ -110,11 +110,11 @@ macro_rules! behavior_write_tests {
 pub async fn test_create_file(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.create().await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -129,13 +129,13 @@ pub async fn test_create_file(op: Operator) -> Result<()> {
 pub async fn test_create_file_existing(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.create().await?;
 
     o.create().await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -150,11 +150,11 @@ pub async fn test_create_file_existing(op: Operator) -> Result<()> {
 pub async fn test_create_file_with_special_chars(op: Operator) -> Result<()> {
     let path = format!("{} !@#$%^&()_+-=;',.txt", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.create().await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
     assert_eq!(meta.mode(), ObjectMode::FILE);
     assert_eq!(meta.content_length(), 0);
 
@@ -169,11 +169,11 @@ pub async fn test_create_file_with_special_chars(op: Operator) -> Result<()> {
 pub async fn test_create_dir(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.create().await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)
@@ -187,13 +187,13 @@ pub async fn test_create_dir(op: Operator) -> Result<()> {
 pub async fn test_create_dir_existing(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
-    let o = op.object(&path);
+    let mut o = op.object(&path);
 
     o.create().await?;
 
     o.create().await?;
 
-    let meta = o.metadata().await?;
+    let meta = o.stat().await?;
     assert_eq!(meta.mode(), ObjectMode::DIR);
 
     op.object(&path)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

refactor: Implement query based object metadata cache
