### PR TITLE
docs: Add services-dashmap feature

### DIFF
--- a/src/docs/features.md
+++ b/src/docs/features.md
@@ -9,6 +9,7 @@ default feature is `rustls` which enable rustls support.
 
 ## Service Features
 
+- `services-dashmap`: Enable dashmap service support.
 - `services-ftp`: Enable ftp service support.
 - `services-hdfs`: Enable hdfs service support.
 - `services-moka`: Enable moka service support.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

add services-dashmap to `opendal::docs::features`

Closes: #1403 