### PR TITLE
refactor: extract check_endpoint.

### DIFF
--- a/src/raw/http_util/mod.rs
+++ b/src/raw/http_util/mod.rs
@@ -42,6 +42,7 @@ pub use header::parse_last_modified;
 pub use header::parse_location;
 
 mod uri;
+pub use uri::check_endpoint;
 pub use uri::percent_encode_path;
 
 mod error;

--- a/src/raw/http_util/uri.rs
+++ b/src/raw/http_util/uri.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{Error, ErrorKind, Scheme};
 use percent_encoding::utf8_percent_encode;
 use percent_encoding::AsciiSet;
 use percent_encoding::NON_ALPHANUMERIC;
+
+/// Result that is a wrapper of `Result<T, opendal::Error>`
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// PATH_ENCODE_SET is the encode set for http url path.
 ///
@@ -42,6 +46,21 @@ static PATH_ENCODE_SET: AsciiSet = NON_ALPHANUMERIC
 /// required by storage services like s3.
 pub fn percent_encode_path(path: &str) -> String {
     utf8_percent_encode(path, &PATH_ENCODE_SET).to_string()
+}
+
+/// check endpoint of service.
+///
+/// If endpoint is empty, return error.
+pub fn check_endpoint(endpoint: &String, schema: Scheme) -> Result<String> {
+    if endpoint.is_empty() {
+        Err(
+            Error::new(ErrorKind::BackendConfigInvalid, "endpoint is empty")
+                .with_operation("Builder::build")
+                .with_context("service", schema),
+        )
+    } else {
+        Ok(endpoint.clone())
+    }
 }
 
 #[cfg(test)]

--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -90,7 +90,7 @@ use crate::*;
 /// ```
 #[derive(Default)]
 pub struct FtpBuilder {
-    endpoint: Option<String>,
+    endpoint: String,
     root: Option<String>,
     user: Option<String>,
     password: Option<String>,
@@ -108,11 +108,7 @@ impl Debug for FtpBuilder {
 impl FtpBuilder {
     /// set endpoint for ftp backend.
     pub fn endpoint(&mut self, endpoint: &str) -> &mut Self {
-        self.endpoint = if endpoint.is_empty() {
-            None
-        } else {
-            Some(endpoint.to_string())
-        };
+        self.endpoint = endpoint.to_string();
 
         self
     }
@@ -157,15 +153,7 @@ impl Builder for FtpBuilder {
 
     fn build(&mut self) -> Result<Self::Accessor> {
         debug!("ftp backend build started: {:?}", &self);
-        let endpoint = match &self.endpoint {
-            None => {
-                return Err(Error::new(
-                    ErrorKind::BackendConfigInvalid,
-                    "endpoint is empty",
-                ))
-            }
-            Some(v) => v,
-        };
+        let endpoint = check_endpoint(&self.endpoint, Scheme::Ftp)?;
 
         let endpoint_uri = match endpoint.parse::<Uri>() {
             Err(e) => {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- extract `check_endpoint` check endpoint of service.
- modify builder `endpoint` from Option<String> -> String.
