### PR TITLE
benches: Generate into Bytes instead

### DIFF
--- a/benches/ops/utils.rs
+++ b/benches/ops/utils.rs
@@ -45,11 +45,11 @@ pub fn services() -> Vec<(&'static str, Option<Operator>)> {
     ]
 }
 
-pub fn gen_bytes(rng: &mut ThreadRng, size: usize) -> Vec<u8> {
+pub fn gen_bytes(rng: &mut ThreadRng, size: usize) -> Bytes {
     let mut content = vec![0; size];
     rng.fill_bytes(&mut content);
 
-    content
+    content.into()
 }
 
 pub struct TempData {
@@ -65,10 +65,10 @@ impl TempData {
         }
     }
 
-    pub fn generate(op: Operator, path: &str, content: Vec<u8>) -> Self {
+    pub fn generate(op: Operator, path: &str, content: Bytes) -> Self {
         TOKIO.block_on(async {
             op.object(path)
-                .write(Bytes::from(content))
+                .write(content)
                 .await
                 .expect("create test data")
         });

--- a/benches/ops/write.rs
+++ b/benches/ops/write.rs
@@ -50,7 +50,7 @@ fn bench_write_once(c: &mut Criterion, name: &str, op: Operator) {
         group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
         group.bench_with_input(
             size.to_string(),
-            &(op.clone(), &path, content),
+            &(op.clone(), &path, content.clone()),
             |b, (op, path, content)| {
                 b.to_async(&*TOKIO).iter(|| async {
                     op.object(path).write(content.clone()).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

benches: Generate into Bytes instead
