### PR TITLE
chore(binding/nodejs): specific packageManager with hash

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -37,5 +37,5 @@
     "universal": "napi universal",
     "version": "napi version"
   },
-  "packageManager": "yarn@3.4.1"
+  "packageManager": "yarn@3.4.1+sha224.cca891d4a8671d4898aba3426674bb734dbbf88cef82dd4dacd71c9f"
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

specific hash as a security practice
