### PR TITLE
chore(bindings-nodejs-deps): update OpenDAL to 0.29.1

### DIFF
--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.11.2", default-features = false, features = ["napi6", "async"] }
 napi-derive = "2.11.1"
-opendal = { version = "0.29", path = "../../"}
+opendal = { version = "0.29.1", path = "../../"}
 chrono = "0.4.23"
 futures = "0.3.26"
 time = { version = "0.3.17", features = ["formatting"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

update bindings/nodejs requirement OpenDAL from 0.29 to 0.29.1
