### PR TITLE
refactor: remove ReadDir in FTP service

### DIFF
--- a/src/services/ftp/backend.rs
+++ b/src/services/ftp/backend.rs
@@ -37,7 +37,6 @@ use time::OffsetDateTime;
 use tokio::sync::OnceCell;
 
 use super::pager::FtpPager;
-use super::pager::ReadDir;
 use super::util::FtpReader;
 use super::writer::FtpWriter;
 use crate::ops::*;
@@ -458,11 +457,9 @@ impl Accessor for FtpBackend {
         let pathname = if path == "/" { None } else { Some(path) };
         let files = ftp_stream.list(pathname).await?;
 
-        let rd = ReadDir::new(files);
-
         Ok((
             RpList::default(),
-            FtpPager::new(if path == "/" { "" } else { path }, rd, args.limit()),
+            FtpPager::new(if path == "/" { "" } else { path }, files, args.limit()),
         ))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

It closes #1438.

We merge the functionality of `services::ftp::ReadDir` into `FtpPager`, and use `std::vec::IntoIter` for more compact code.
