### PR TITLE
feat(bindings/python): add support for services that opendal enables by default

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 
 use ::opendal as od;
 use pyo3::create_exception;
-use pyo3::exceptions::{PyException, PyFileNotFoundError};
+use pyo3::exceptions::{PyException, PyFileNotFoundError, PyNotImplementedError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use pyo3_asyncio::tokio::future_into_py;
@@ -28,13 +28,48 @@ fn build_operator(scheme: od::Scheme, map: HashMap<String, String>) -> PyResult<
     use od::services::*;
 
     let op = match scheme {
-        od::Scheme::Memory => od::Operator::from_map::<Memory>(map)
+        od::Scheme::Azblob => od::Operator::from_map::<Azblob>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Azdfs => od::Operator::from_map::<Azdfs>(map)
             .map_err(format_pyerr)?
             .finish(),
         od::Scheme::Fs => od::Operator::from_map::<Fs>(map)
             .map_err(format_pyerr)?
             .finish(),
-        _ => unimplemented!("not supported"),
+        od::Scheme::Gcs => od::Operator::from_map::<Gcs>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Ghac => od::Operator::from_map::<Ghac>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Http => od::Operator::from_map::<Http>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Ipmfs => od::Operator::from_map::<Ipmfs>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Memory => od::Operator::from_map::<Memory>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Obs => od::Operator::from_map::<Obs>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Oss => od::Operator::from_map::<Oss>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::S3 => od::Operator::from_map::<S3>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Webdav => od::Operator::from_map::<Webdav>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        od::Scheme::Webhdfs => od::Operator::from_map::<Webhdfs>(map)
+            .map_err(format_pyerr)?
+            .finish(),
+        _ => Err(PyNotImplementedError::new_err(format!(
+            "unsupported scheme `{scheme}`"
+        )))?,
     };
 
     Ok(op)

--- a/bindings/python/tests/test_core.py
+++ b/bindings/python/tests/test_core.py
@@ -59,3 +59,6 @@ def test_error():
     op = opendal.Operator("memory")
     with pytest.raises(FileNotFoundError):
         op.read("test")
+
+    with pytest.raises(NotImplementedError):
+        opendal.Operator("foobar")


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Add support for services that opendal enables by default, thanks to Copilot!
