### PR TITLE
docs(bindings/python): Add building docs

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,3 +1,36 @@
 # OpenDAL Python Binding
 
 This crate intends to build a native python binding.
+
+## Building
+
+Install `maturin`:
+
+```shell
+pip install maturin
+```
+
+Setup virtualenv:
+
+```shell
+virtualenv venv
+```
+
+Activate venv:
+
+```shell
+source venv/bin/activate
+````
+
+Build bindings:
+
+```shell
+maturin develop
+```
+
+Running some tests:
+
+```shell
+pip install -r test_requirements.txt
+pytest
+```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

docs(bindings/python): Add building docs