### PR TITLE
feat(bindings/nodejs): Remove `Operator.writer` until we are ready

### DIFF
--- a/bindings/nodejs/__test__/index.spec.ts
+++ b/bindings/nodejs/__test__/index.spec.ts
@@ -83,28 +83,3 @@ test('test scan', async (t) => {
     await op.delete(path)
   })
 })
-
-
-test('test writer', async (t) => {
-  let op = new Operator(Scheme.Memory)
-  const path = 'test'
-
-  let contents = [
-    'hello',
-    'world',
-    '!'
-  ]
-
-  let writer = await op.writer(path)
-
-  for (let part of contents) {
-    await writer.append(Buffer.from(part))
-  }
-
-  writer.close()
-
-  let c = new TextDecoder().decode(await op.read(path))
-
-  t.is(c, contents.join(''))
-})
-

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -199,13 +199,6 @@ impl Operator {
     pub async fn list(&self, path: String) -> Result<Lister> {
         Ok(Lister(self.0.list(&path).await.map_err(format_napi_error)?))
     }
-
-    #[napi]
-    pub async fn writer(&self, path: String) -> Result<Writer> {
-        Ok(Writer(
-            self.0.writer(&path).await.map_err(format_napi_error)?,
-        ))
-    }
 }
 
 #[napi]
@@ -310,35 +303,6 @@ impl Lister {
             .await
             .map_err(format_napi_error)?
             .map(Entry))
-    }
-}
-
-#[napi]
-pub struct Writer(opendal::Writer);
-
-#[napi]
-impl Writer {
-    /// # Safety
-    ///
-    /// > &mut self in async napi methods should be marked as unsafe
-    ///
-    /// napi will make sure the function is safe, and we didn't do unsafe
-    /// thing internally.
-    #[napi]
-    pub async unsafe fn append(&mut self, content: Either<Buffer, String>) -> Result<()> {
-        let c = content.as_ref().to_owned();
-        self.0.append(c).await.map_err(format_napi_error)
-    }
-
-    /// # Safety
-    ///
-    /// > &mut self in async napi methods should be marked as unsafe
-    ///
-    /// napi will make sure the function is safe, and we didn't do unsafe
-    /// thing internally.
-    #[napi]
-    pub async unsafe fn close(&mut self) -> Result<()> {
-        self.0.close().await.map_err(format_napi_error)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

remove `Operator.writer` until we are ready