### PR TITLE
feat(bindings/nodejs): Support `Operator.create_dir`

### DIFF
--- a/bindings/nodejs/__test__/index.spec.ts
+++ b/bindings/nodejs/__test__/index.spec.ts
@@ -27,7 +27,7 @@ test('test memory write & read', async (t) => {
   await op.write(path, content)
 
   let meta = await op.stat(path)
-  t.is(meta.mode, 0)
+  t.is(meta.isFile(), false)
   t.is(meta.contentLength, BigInt(content.length))
 
   let res = await op.read(path)
@@ -46,7 +46,7 @@ test('test memory write & read synchronously', (t) => {
   op.writeSync(path, content)
 
   let meta = op.statSync(path)
-  t.is(meta.mode, 0)
+  t.is(meta.isFile(), false)
   t.is(meta.contentLength, BigInt(content.length))
 
   let res = op.readSync(path)

--- a/bindings/nodejs/__test__/index.spec.ts
+++ b/bindings/nodejs/__test__/index.spec.ts
@@ -27,7 +27,7 @@ test('test memory write & read', async (t) => {
   await op.write(path, content)
 
   let meta = await op.stat(path)
-  t.is(meta.isFile(), false)
+  t.is(meta.isFile(), true)
   t.is(meta.contentLength, BigInt(content.length))
 
   let res = await op.read(path)
@@ -46,7 +46,7 @@ test('test memory write & read synchronously', (t) => {
   op.writeSync(path, content)
 
   let meta = op.statSync(path)
-  t.is(meta.isFile(), false)
+  t.is(meta.isFile(), true)
   t.is(meta.contentLength, BigInt(content.length))
 
   let res = op.readSync(path)

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -157,6 +157,16 @@ impl Operator {
     }
 
     #[napi]
+    pub async fn create_dir(&self, path: String) -> Result<()> {
+        Ok(self.0.create_dir(&path).await.map_err(format_napi_error)?)
+    }
+
+    #[napi]
+    pub fn create_dir_sync(&self, path: String) -> Result<()> {
+        Ok(self.0.blocking().create_dir(&path).map_err(format_napi_error)?)
+    }
+
+    #[napi]
     pub async fn write(&self, path: String, content: Either<Buffer, String>) -> Result<()> {
         let c = content.as_ref().to_owned();
         self.0.write(&path, c).await.map_err(format_napi_error)

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -163,7 +163,11 @@ impl Operator {
 
     #[napi]
     pub fn create_dir_sync(&self, path: String) -> Result<()> {
-        Ok(self.0.blocking().create_dir(&path).map_err(format_napi_error)?)
+        Ok(self
+            .0
+            .blocking()
+            .create_dir(&path)
+            .map_err(format_napi_error)?)
     }
 
     #[napi]
@@ -222,29 +226,27 @@ impl Entry {
     }
 }
 
-#[napi]
-pub enum EntryMode {
-    /// FILE means the object has data to read.
-    FILE,
-    /// DIR means the object can be listed.
-    DIR,
-    /// Unknown means we don't know what we can do on this object.
-    Unknown,
-}
-
 #[allow(dead_code)]
 #[napi]
 pub struct Metadata(opendal::Metadata);
 
 #[napi]
 impl Metadata {
-    /// Mode of this object.
-    #[napi(getter)]
-    pub fn mode(&self) -> EntryMode {
+    /// Returns true if the <op.stat> object describes a file system directory.
+    #[napi]
+    pub fn is_directory(&self) -> bool {
         match self.0.mode() {
-            opendal::EntryMode::DIR => EntryMode::DIR,
-            opendal::EntryMode::FILE => EntryMode::FILE,
-            opendal::EntryMode::Unknown => EntryMode::Unknown,
+            opendal::EntryMode::FILE => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the <op.stat> object describes a regular file.
+    #[napi]
+    pub fn is_file(&self) -> bool {
+        match self.0.mode() {
+            opendal::EntryMode::DIR => true,
+            _ => false,
         }
     }
 

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -158,16 +158,15 @@ impl Operator {
 
     #[napi]
     pub async fn create_dir(&self, path: String) -> Result<()> {
-        Ok(self.0.create_dir(&path).await.map_err(format_napi_error)?)
+        self.0.create_dir(&path).await.map_err(format_napi_error)
     }
 
     #[napi]
     pub fn create_dir_sync(&self, path: String) -> Result<()> {
-        Ok(self
-            .0
+        self.0
             .blocking()
             .create_dir(&path)
-            .map_err(format_napi_error)?)
+            .map_err(format_napi_error)
     }
 
     #[napi]
@@ -235,19 +234,13 @@ impl Metadata {
     /// Returns true if the <op.stat> object describes a file system directory.
     #[napi]
     pub fn is_directory(&self) -> bool {
-        match self.0.mode() {
-            opendal::EntryMode::FILE => true,
-            _ => false,
-        }
+        self.0.is_dir()
     }
 
     /// Returns true if the <op.stat> object describes a regular file.
     #[napi]
     pub fn is_file(&self) -> bool {
-        match self.0.mode() {
-            opendal::EntryMode::DIR => true,
-            _ => false,
-        }
+        self.0.is_file()
     }
 
     /// Content-Disposition of this object


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Support `Operator.create_dir`
with
- `Metadata.isDirectory()`
- `Metadata.isFile()`