### PR TITLE
feat: add write buffer support for S3

### DIFF
--- a/src/raw/oio/write.rs
+++ b/src/raw/oio/write.rs
@@ -86,6 +86,15 @@ pub trait Write: Unpin + Send + Sync {
 
     /// Close the writer and make sure all data has been flushed.
     async fn close(&mut self) -> Result<()>;
+
+    /// Flush the writer
+    ///
+    /// OpenDAL will maintain a 4MiB buffer so that it can use some high performanced
+    /// API of underlying storage service.
+    /// Calling this will make sure all data in the buffer has been flushed.
+    async fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/src/services/s3/writer.rs
+++ b/src/services/s3/writer.rs
@@ -14,6 +14,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use bytes::BytesMut;
 use http::StatusCode;
 
 use super::backend::CompleteMultipartUploadRequestPart;
@@ -23,8 +24,16 @@ use crate::ops::OpWrite;
 use crate::raw::*;
 use crate::*;
 
+/// the size of parts limit for append
+const PART_LIMIT: usize = 4 * 1024 * 1024;
+/// size of buffer
+/// double capacity should reduce some copy of vector
+const BUF_SIZE: usize = 2 * PART_LIMIT;
+
 pub struct S3Writer {
     backend: S3Backend,
+    // write buffer for append
+    buffer: BytesMut,
 
     op: OpWrite,
     path: String,
@@ -37,6 +46,7 @@ impl S3Writer {
     pub fn new(backend: S3Backend, op: OpWrite, path: String, upload_id: Option<String>) -> Self {
         S3Writer {
             backend,
+            buffer: BytesMut::with_capacity(BUF_SIZE),
             op,
             path,
             upload_id,
@@ -80,11 +90,59 @@ impl oio::Write for S3Writer {
     }
 
     async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let upload_id = self.upload_id.as_ref().expect(
-            "Writer doesn't have upload id, but users trying to call append, must be buggy",
-        );
+        if self.upload_id.is_some() {
+            panic!(
+                "Writer initiated with upload id, but users trying to call write, must be buggy"
+            );
+        }
+
+        // A new buffer is introduced
+        //
+        // for the convenience of flushing
+        // the size of our buffer should always be kept as {0} ∪ [PART_LIMIT, BUF_SIZE) bytes!
+        let bs: Bytes = if bs.len() < PART_LIMIT {
+            if bs.len() + self.buffer.len() < BUF_SIZE {
+                // will not exceed limit of buffer, extend buffer directly
+                self.buffer.extend_from_slice(&bs);
+                return Ok(());
+            }
+            // truncate the first bytes of buffer
+            let trunk_size = bs.len() + self.buffer.len() - PART_LIMIT;
+            let trunk = self.buffer.split_to(trunk_size);
+
+            self.buffer.extend_from_slice(&bs);
+            debug_assert!(self.buffer.len() >= PART_LIMIT);
+
+            trunk.freeze()
+        } else if bs.len() < BUF_SIZE {
+            // larger than PART_LIMIT, replace into buffer
+
+            // flush all data in buffer
+            self.flush().await?;
+            // take the last part of data (larger than PART_LIMIT) in our buffer
+            self.buffer.extend_from_slice(&bs);
+            return Ok(());
+        } else {
+            // flush all data in the buffer
+            // and then write the data in bs directly (to minimize copy)
+            // finally, keep the last part of data (larger than PART_LIMIT) in our buffer
+
+            self.flush().await?;
+            // size of directly write trunk
+            let trunk_size = (bs.len() / (PART_LIMIT) - 1) * (PART_LIMIT);
+
+            // direct write trunk
+            let mut bs = bs;
+            let buf = bs.split_to(trunk_size);
+            self.buffer.extend_from_slice(&bs);
+
+            buf
+        };
+
         // AWS S3 requires part number must between [1..=10000]
         let part_number = self.parts.len() + 1;
+
+        let upload_id = self.upload_id.as_ref().unwrap();
 
         let mut req = self.backend.s3_upload_part_request(
             &self.path,
@@ -126,6 +184,10 @@ impl oio::Write for S3Writer {
     }
 
     async fn close(&mut self) -> Result<()> {
+        if !self.buffer.is_empty() {
+            self.flush().await?;
+        }
+
         let upload_id = if let Some(upload_id) = &self.upload_id {
             upload_id
         } else {
@@ -142,6 +204,59 @@ impl oio::Write for S3Writer {
         match status {
             StatusCode::OK => {
                 resp.into_body().consume().await?;
+
+                Ok(())
+            }
+            _ => Err(parse_error(resp).await?),
+        }
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        let upload_id = match self.upload_id.as_ref() {
+            Some(upload_id) => upload_id,
+            // call on normal write? tolerate this.
+            None => return Ok(()),
+        };
+
+        let bs = std::mem::take(&mut self.buffer);
+        self.buffer = BytesMut::with_capacity(BUF_SIZE);
+        let bs = bs.freeze();
+
+        // AWS S3 requires part number must between [1..=10000]
+        let part_number = self.parts.len() + 1;
+
+        let mut req = self.backend.s3_upload_part_request(
+            &self.path,
+            upload_id,
+            part_number,
+            Some(bs.len() as u64),
+            AsyncBody::Bytes(bs),
+        )?;
+
+        self.backend
+            .signer
+            .sign(&mut req)
+            .map_err(new_request_sign_error)?;
+
+        let resp = self.backend.client.send_async(req).await?;
+
+        let status = resp.status();
+
+        match status {
+            StatusCode::OK => {
+                let etag = parse_etag(resp.headers())?
+                    .ok_or_else(|| {
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            "ETag not present in returning response",
+                        )
+                    })?
+                    .to_string();
+
+                resp.into_body().consume().await?;
+
+                self.parts
+                    .push(CompleteMultipartUploadRequestPart { part_number, etag });
 
                 Ok(())
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

This PR implements a write buffer for S3.

For the convenience of flushing, the buffer will always ensure it contains data more than the minimal limit of writing multipart. 
