### PR TITLE
chore: Move memcache-async into opendal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,15 +1799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memcache-async"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a114106a13014b37b174cd14ae13c3ac229f2cecc7174fe2f2c6c999ea4ee7"
-dependencies = [
- "futures",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,7 +2144,6 @@ dependencies = [
  "librocksdb-sys",
  "log",
  "md-5",
- "memcache-async",
  "metrics",
  "moka",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ services-hdfs = ["dep:hdrs"]
 # Enable services ipfs support
 services-ipfs = ["dep:prost"]
 # Enable services memcached support
-services-memcached = ["dep:bb8", "dep:memcache-async"]
+services-memcached = ["dep:bb8"]
 # Enable services moka support
 services-moka = ["dep:moka"]
 # Enable services redis support
@@ -117,7 +117,6 @@ lazy-regex = { version = "2.4.1", optional = true }
 librocksdb-sys = { version = "=6.11", optional = true }
 log = "0.4"
 md-5 = "0.10"
-memcache-async = { version = "0.6", optional = true }
 metrics = { version = "0.20", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -17,9 +17,12 @@ use std::str::FromStr;
 
 use ::opendal as od;
 use pyo3::create_exception;
-use pyo3::exceptions::{PyException, PyFileNotFoundError, PyNotImplementedError};
+use pyo3::exceptions::PyException;
+use pyo3::exceptions::PyFileNotFoundError;
+use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::PyBytes;
+use pyo3::types::PyDict;
 use pyo3_asyncio::tokio::future_into_py;
 
 create_exception!(opendal, Error, PyException);

--- a/src/services/memcached/MIT-ascii.txt
+++ b/src/services/memcached/MIT-ascii.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 An Long
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/services/memcached/ascii.rs
+++ b/src/services/memcached/ascii.rs
@@ -1,0 +1,278 @@
+// Copyright 2017 vavrusa <marek@vavrusa.com>
+//
+// Licensed under the MIT License (see MIT-ascii.txt);
+//
+// Copyright 2022 Datafuse Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Display;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::marker::Unpin;
+
+use futures::io::AsyncBufReadExt;
+use futures::io::AsyncRead;
+use futures::io::AsyncReadExt;
+use futures::io::AsyncWrite;
+use futures::io::AsyncWriteExt;
+use futures::io::BufReader;
+
+/// Memcache ASCII protocol implementation.
+pub struct Protocol<S> {
+    io: BufReader<S>,
+    buf: Vec<u8>,
+}
+
+impl<S> Protocol<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Creates the ASCII protocol on a stream.
+    pub fn new(io: S) -> Self {
+        Self {
+            io: BufReader::new(io),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Returns the value for given key as bytes. If the value doesn't exist, [`ErrorKind::NotFound`] is returned.
+    pub async fn get<K: AsRef<[u8]>>(&mut self, key: K) -> Result<Vec<u8>, Error> {
+        // Send command
+        let writer = self.io.get_mut();
+        writer
+            .write_all(&[b"get ", key.as_ref(), b"\r\n"].concat())
+            .await?;
+        writer.flush().await?;
+
+        // Read response header
+        let header = self.read_line().await?;
+        let header = std::str::from_utf8(header).map_err(|_| ErrorKind::InvalidData)?;
+
+        // Check response header and parse value length
+        if header.contains("ERROR") {
+            return Err(Error::new(ErrorKind::Other, header));
+        } else if header.starts_with("END") {
+            return Err(ErrorKind::NotFound.into());
+        }
+
+        // VALUE <key> <flags> <bytes> [<cas unique>]\r\n
+        let length: usize = header
+            .split(' ')
+            .nth(3)
+            .and_then(|len| len.trim_end().parse().ok())
+            .ok_or(ErrorKind::InvalidData)?;
+
+        // Read value
+        let mut buffer: Vec<u8> = vec![0; length];
+        self.io.read_exact(&mut buffer).await?;
+
+        // Read the trailing header
+        self.read_line().await?; // \r\n
+        self.read_line().await?; // END\r\n
+
+        Ok(buffer)
+    }
+
+    /// Set key to given value and don't wait for response.
+    pub async fn set<K: Display>(
+        &mut self,
+        key: K,
+        val: &[u8],
+        expiration: u32,
+    ) -> Result<(), Error> {
+        let header = format!("set {} 0 {} {} noreply\r\n", key, expiration, val.len());
+        self.io.write_all(header.as_bytes()).await?;
+        self.io.write_all(val).await?;
+        self.io.write_all(b"\r\n").await?;
+        self.io.flush().await?;
+        Ok(())
+    }
+
+    /// Delete a key and don't wait for response.
+    pub async fn delete<K: Display>(&mut self, key: K) -> Result<(), Error> {
+        let header = format!("delete {} noreply\r\n", key);
+        self.io.write_all(header.as_bytes()).await?;
+        self.io.flush().await?;
+        Ok(())
+    }
+
+    /// Return the version of the remote server.
+    pub async fn version(&mut self) -> Result<String, Error> {
+        self.io.write_all(b"version\r\n").await?;
+        self.io.flush().await?;
+
+        // Read response header
+        let header = {
+            let buf = self.read_line().await?;
+            std::str::from_utf8(buf).map_err(|_| Error::from(ErrorKind::InvalidData))?
+        };
+
+        if !header.starts_with("VERSION") {
+            return Err(Error::new(ErrorKind::Other, header));
+        }
+        let version = header.trim_start_matches("VERSION ").trim_end();
+        Ok(version.to_string())
+    }
+
+    async fn read_line(&mut self) -> Result<&[u8], Error> {
+        let Self { io, buf } = self;
+        buf.clear();
+        io.read_until(b'\n', buf).await?;
+        if buf.last().copied() != Some(b'\n') {
+            return Err(ErrorKind::UnexpectedEof.into());
+        }
+        Ok(&buf[..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::io::Error;
+    use std::io::ErrorKind;
+    use std::io::Read;
+    use std::io::Write;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    use futures::executor::block_on;
+    use futures::io::AsyncRead;
+    use futures::io::AsyncWrite;
+
+    struct Cache {
+        r: Cursor<Vec<u8>>,
+        w: Cursor<Vec<u8>>,
+    }
+
+    impl Cache {
+        fn new() -> Self {
+            Cache {
+                r: Cursor::new(Vec::new()),
+                w: Cursor::new(Vec::new()),
+            }
+        }
+    }
+
+    impl AsyncRead for Cache {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize, Error>> {
+            Poll::Ready(self.get_mut().r.read(buf))
+        }
+    }
+
+    impl AsyncWrite for Cache {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context,
+            buf: &[u8],
+        ) -> Poll<Result<usize, Error>> {
+            Poll::Ready(self.get_mut().w.write(buf))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<(), Error>> {
+            Poll::Ready(self.get_mut().w.flush())
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn test_ascii_get() {
+        let mut cache = Cache::new();
+        cache
+            .r
+            .get_mut()
+            .extend_from_slice(b"VALUE foo 0 3\r\nbar\r\nEND\r\n");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(block_on(ascii.get(&"foo")).unwrap(), b"bar");
+        assert_eq!(cache.w.get_ref(), b"get foo\r\n");
+    }
+
+    #[test]
+    fn test_ascii_get2() {
+        let mut cache = Cache::new();
+        cache
+            .r
+            .get_mut()
+            .extend_from_slice(b"VALUE foo 0 3\r\nbar\r\nEND\r\nVALUE bar 0 3\r\nbaz\r\nEND\r\n");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(block_on(ascii.get(&"foo")).unwrap(), b"bar");
+        assert_eq!(block_on(ascii.get(&"bar")).unwrap(), b"baz");
+    }
+
+    #[test]
+    fn test_ascii_get_cas() {
+        let mut cache = Cache::new();
+        cache
+            .r
+            .get_mut()
+            .extend_from_slice(b"VALUE foo 0 3 99999\r\nbar\r\nEND\r\n");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(block_on(ascii.get(&"foo")).unwrap(), b"bar");
+        assert_eq!(cache.w.get_ref(), b"get foo\r\n");
+    }
+
+    #[test]
+    fn test_ascii_get_empty() {
+        let mut cache = Cache::new();
+        cache.r.get_mut().extend_from_slice(b"END\r\n");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(
+            block_on(ascii.get(&"foo")).unwrap_err().kind(),
+            ErrorKind::NotFound
+        );
+        assert_eq!(cache.w.get_ref(), b"get foo\r\n");
+    }
+
+    #[test]
+    fn test_ascii_get_eof_error() {
+        let mut cache = Cache::new();
+        cache.r.get_mut().extend_from_slice(b"EN");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(
+            block_on(ascii.get(&"foo")).unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+        assert_eq!(cache.w.get_ref(), b"get foo\r\n");
+    }
+
+    #[test]
+    fn test_ascii_set() {
+        let (key, val, ttl) = ("foo", "bar", 5);
+        let mut cache = Cache::new();
+        let mut ascii = super::Protocol::new(&mut cache);
+        block_on(ascii.set(&key, val.as_bytes(), ttl)).unwrap();
+        assert_eq!(
+            cache.w.get_ref(),
+            &format!("set {} 0 {} {} noreply\r\n{}\r\n", key, ttl, val.len(), val)
+                .as_bytes()
+                .to_vec()
+        );
+    }
+
+    #[test]
+    fn test_ascii_version() {
+        let mut cache = Cache::new();
+        cache.r.get_mut().extend_from_slice(b"VERSION 1.6.6\r\n");
+        let mut ascii = super::Protocol::new(&mut cache);
+        assert_eq!(block_on(ascii.version()).unwrap(), "1.6.6");
+        assert_eq!(cache.w.get_ref(), b"version\r\n");
+    }
+}

--- a/src/services/memcached/backend.rs
+++ b/src/services/memcached/backend.rs
@@ -21,6 +21,7 @@ use bb8::RunError;
 use tokio::net::TcpStream;
 use tokio::sync::OnceCell;
 
+use super::ascii;
 use crate::raw::adapters::kv;
 use crate::raw::*;
 use crate::*;
@@ -36,7 +37,7 @@ use crate::*;
 /// - [ ] ~~list~~
 /// - [ ] scan
 /// - [ ] ~~presign~~
-/// - [x] blocking
+/// - [ ] blocking
 ///
 /// # Configuration
 ///
@@ -307,13 +308,13 @@ impl MemcacheConnectionManager {
 
 #[async_trait]
 impl bb8::ManageConnection for MemcacheConnectionManager {
-    type Connection = memcache_async::ascii::Protocol<Compat<TcpStream>>;
+    type Connection = ascii::Protocol<Compat<TcpStream>>;
     type Error = std::io::Error;
 
     /// TODO: Implement unix stream support.
     async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
         let sock = TcpStream::connect(&self.address).await?;
-        Ok(memcache_async::ascii::Protocol::new(Compat::new(sock)))
+        Ok(ascii::Protocol::new(Compat::new(sock)))
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {

--- a/src/services/memcached/mod.rs
+++ b/src/services/memcached/mod.rs
@@ -14,3 +14,5 @@
 
 mod backend;
 pub use backend::MemcachedBuilder as Memcached;
+
+mod ascii;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

chore: Move memcache-async into opendal

Fix https://github.com/datafuselabs/opendal/issues/1542

cc @tisonkun for review license.
