### PR TITLE
docs: Fix `Operator::create()` has been removed

### DIFF
--- a/src/types/builder.rs
+++ b/src/types/builder.rs
@@ -20,7 +20,7 @@ use crate::*;
 
 /// Builder is used to build a storage accessor used by [`Operator`].
 ///
-/// It's recommended to use [`Operator::create`] instead of [`Operator::new`] to avoid use `Builder` trait directly.
+/// It's recommended to use [`Operator::new`] to avoid use `Builder` trait directly.
 pub trait Builder: Default {
     /// Associated scheme for this builder.
     const SCHEME: Scheme;

--- a/src/types/operator/builder.rs
+++ b/src/types/operator/builder.rs
@@ -21,7 +21,7 @@ use crate::*;
 
 /// # Operator build API
 ///
-/// Operator should be built via [`OperatorBuilder`]. We recommend to use [`Operator::create`] to get started:
+/// Operator should be built via [`OperatorBuilder`]. We recommend to use [`Operator::new`] to get started:
 ///
 /// ```
 /// # use anyhow::Result;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

docs: Fix `Operator::create()` has been removed