### PR TITLE
fix: reset Reader::SeekState when poll completed

### DIFF
--- a/src/types/reader.rs
+++ b/src/types/reader.rs
@@ -152,6 +152,7 @@ impl tokio::io::AsyncSeek for Reader {
             }
             SeekState::Start(pos) => {
                 let n = ready!(self.inner.poll_seek(cx, pos))?;
+                self.get_mut().seek_state = SeekState::Init;
                 Poll::Ready(Ok(n))
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

a following `seek` will error with `another search is in progress` 
